### PR TITLE
Default families

### DIFF
--- a/.github/workflows/metanorma.yml
+++ b/.github/workflows/metanorma.yml
@@ -2,8 +2,10 @@ name: metanorma
 
 on:
   push:
+    # switch to the v2 branch after metanorma upgrade
     branches: [ master ]
-  pull_request:
+  # enable after metanorma upgrade to v2 formulas
+  # pull_request:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,31 @@
+name: test
+
+on:
+  push:
+    branches: [ v2 ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest ]
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: jitterbit/get-changed-files@v1
+        id: files
+        with:
+          format: 'json'
+
+      - run: |
+          echo '${{ steps.files.outputs.added_modified }}' > changed.json
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 2.5
+          bundler-cache: true
+
+      - run: bundle exec ruby test/test_formulas.rb

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /Formulas/private/*
 !/Formulas/private/.keep
+/.bundle/
+/Gemfile.lock
+/changed.json

--- a/Formulas/adobe_reader_19.yml
+++ b/Formulas/adobe_reader_19.yml
@@ -46,14 +46,6 @@ fonts:
 - name: Adobe Devanagari
   styles:
   - family_name: Adobe Devanagari
-    type: Regular
-    full_name: AdobeDevanagari-Regular
-    post_script_name: AdobeDevanagari-Regular
-    version: 2.002;PS 2.000;hotconv 1.0.70;makeotf.lib2.5.5900
-    copyright: Copyright 2000, 2002, 2006, 2011, 2012 Adobe Systems Incorporated.
-      All Rights Reserved.
-    font: adobedevanagari_regular.otf
-  - family_name: Adobe Devanagari
     type: Bold
     full_name: AdobeDevanagari-Bold
     post_script_name: AdobeDevanagari-Bold
@@ -78,26 +70,42 @@ fonts:
     copyright: Copyright 2000, 2002, 2006, 2011, 2012 Adobe Systems Incorporated.
       All Rights Reserved.
     font: adobedevanagari_italic.otf
-- name: Adobe Fan Heiti Std
+  - family_name: Adobe Devanagari
+    type: Regular
+    full_name: AdobeDevanagari-Regular
+    post_script_name: AdobeDevanagari-Regular
+    version: 2.002;PS 2.000;hotconv 1.0.70;makeotf.lib2.5.5900
+    copyright: Copyright 2000, 2002, 2006, 2011, 2012 Adobe Systems Incorporated.
+      All Rights Reserved.
+    font: adobedevanagari_regular.otf
+- name: Adobe Fan Heiti Std B
   styles:
-  - family_name: Adobe Fan Heiti Std
-    type: B
+  - family_name: Adobe Fan Heiti Std B
+    type: Bold
+    preferred_family_name: Adobe Fan Heiti Std
+    preferred_type: B
     full_name: AdobeFanHeitiStd-Bold
     post_script_name: AdobeFanHeitiStd-Bold
     version: 6.009;PS 6.001;hotconv 1.0.67;makeotf.lib2.5.33168
     copyright: Copyright © 2009, 2011 Adobe Systems Incorporated. All Rights Reserved.
     font: adobefanheitistd_bold.otf
-- name: Adobe Gothic Std
+- name: Adobe Gothic Std B
   styles:
-  - family_name: Adobe Gothic Std
-    type: B
+  - family_name: Adobe Gothic Std B
+    type: Bold
+    preferred_family_name: Adobe Gothic Std
+    preferred_type: B
     full_name: AdobeGothicStd-Bold
     post_script_name: AdobeGothicStd-Bold
     version: 1.015;PS 1.004;hotconv 1.0.70;makeotf.lib2.5.58329
     copyright: Copyright © 2009-2012 Adobe Systems Incorporated. All Rights Reserved.
     font: adobegothicstd_bold.otf
-  - family_name: Adobe Gothic Std
-    type: L
+- name: Adobe Gothic Std L
+  styles:
+  - family_name: Adobe Gothic Std L
+    type: Regular
+    preferred_family_name: Adobe Gothic Std
+    preferred_type: L
     full_name: Adobe Gothic Std L
     post_script_name: AdobeGothicStd-Light
     version: 1.006;PS 1.001;hotconv 1.0.70;makeotf.lib2.5.58329
@@ -137,39 +145,47 @@ fonts:
     copyright: Copyright 2000, 2002, 2004, 2005, 2006, 2007, 2008, 2013 Adobe Systems
       Incorporated. All Rights Reserved.
     font: AdobeHebrew_Regular.otf
-- name: Adobe Heiti Std
+- name: Adobe Heiti Std R
   styles:
-  - family_name: Adobe Heiti Std
-    type: R
+  - family_name: Adobe Heiti Std R
+    type: Regular
+    preferred_family_name: Adobe Heiti Std
+    preferred_type: R
     full_name: AdobeHeitiStd-Regular
     post_script_name: AdobeHeitiStd-Regular
     version: 5.019;PS 5.007;hotconv 1.0.68;makeotf.lib2.5.35818
     copyright: Copyright © 2006, 2008-2011 Adobe Systems Incorporated. All Rights
       Reserved.
     font: AdobeHeitiStd_Regular.otf
-- name: Adobe Ming Std
+- name: Adobe Ming Std L
   styles:
-  - family_name: Adobe Ming Std
-    type: L
+  - family_name: Adobe Ming Std L
+    type: Regular
+    preferred_family_name: Adobe Ming Std
+    preferred_type: L
     full_name: AdobeMingStd-Light
     post_script_name: AdobeMingStd-Light
     version: 6.009;PS 6.001;hotconv 1.0.67;makeotf.lib2.5.33168
     copyright: Copyright © 1996-2011 Adobe Systems Incorporated. All Rights Reserved.
     font: AdobeMingStd_Light.otf
-- name: Adobe Myungjo Std
+- name: Adobe Myungjo Std M
   styles:
-  - family_name: Adobe Myungjo Std
-    type: M
+  - family_name: Adobe Myungjo Std M
+    type: Regular
+    preferred_family_name: Adobe Myungjo Std
+    preferred_type: M
     full_name: AdobeMyungjoStd-Medium
     post_script_name: AdobeMyungjoStd-Medium
     version: 1.015;PS 1.004;hotconv 1.0.70;makeotf.lib2.5.58329
     copyright: Copyright © 1996-2005, 2008-2012 Adobe Systems Incorporated. All Rights
       Reserved.
     font: AdobeMyungjoStd_Medium.otf
-- name: Adobe Song Std
+- name: Adobe Song Std L
   styles:
-  - family_name: Adobe Song Std
-    type: L
+  - family_name: Adobe Song Std L
+    type: Regular
+    preferred_family_name: Adobe Song Std
+    preferred_type: L
     full_name: AdobeSongStd-Light
     post_script_name: AdobeSongStd-Light
     version: 5.018;PS 5.002;hotconv 1.0.67;makeotf.lib2.5.33168
@@ -206,20 +222,24 @@ fonts:
     version: '1.043'
     copyright: Copyright 2000, 2002, 2004 Adobe Systems Incorporated. All Rights Reserved.
     font: AdobeThai_Regular.otf
-- name: Kozuka Gothic Pr6N
+- name: Kozuka Gothic Pr6N M
   styles:
-  - family_name: Kozuka Gothic Pr6N
-    type: M
+  - family_name: Kozuka Gothic Pr6N M
+    type: Regular
+    preferred_family_name: Kozuka Gothic Pr6N
+    preferred_type: M
     full_name: KozGoPr6N-Medium
     post_script_name: KozGoPr6N-Medium
     version: 7.001;hotconv 1.0.107;makeotfexe 2.5.65593
     description: Dr. Ken Lunde (overall production) & Masataka HATTORI 服部正貴 (production)
     copyright: "© 2001-2019 Adobe. All rights reserved."
     font: kozgopr6n_medium.otf
-- name: Kozuka Mincho Pr6N
+- name: Kozuka Mincho Pr6N R
   styles:
-  - family_name: Kozuka Mincho Pr6N
-    type: R
+  - family_name: Kozuka Mincho Pr6N R
+    type: Regular
+    preferred_family_name: Kozuka Mincho Pr6N
+    preferred_type: R
     full_name: KozMinPr6N-Regular
     post_script_name: KozMinPr6N-Regular
     version: 7.001;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -294,11 +314,9 @@ fonts:
     copyright: "© 1992, 1994, 1997, 2000, 2004, 2011 Adobe Systems Incorporated. All
       rights reserved."
     font: myriadhebrew_regular.otf
-extract:
-- format: msi
-- format: cab
-copyright: Copyright © 1996-2006, 2008-2011 Adobe Systems Incorporated. All Rights
-  Reserved.
+extract: {}
+copyright: Copyright 2000, 2002, 2004, 2005, 2006, 2007, 2008, 2013 Adobe Systems
+  Incorporated. All Rights Reserved.
 license_url: http://www.adobe.com/type/legal.html
 requires_license_agreement: |-
   Adobe End-User License Agreement
@@ -313,3 +331,4 @@ requires_license_agreement: |-
   DISCLAIMER OF WARRANTIES: YOU AGREE THAT ADOBE HAS MADE NO EXPRESS WARRANTIES TO YOU REGARDING THE SOFTWARE AND THAT THE SOFTWARE IS BEING PROVIDED TO YOU "AS IS" WITHOUT WARRANTY OF ANY KIND. ADOBE DISCLAIMS ALL WARRANTIES WITH REGARD TO THE SOFTWARE, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, MERCHANTABLE QUALITY, OR NONINFRINGEMENT OF THIRD-PARTY RIGHTS. Some states or jurisdictions do not allow the exclusion of implied warranties, so the above limitations may not apply to you.
 
   LIMIT OF LIABILITY: IN NO EVENT WILL ADOBE BE LIABLE TO YOU FOR ANY LOSS OF USE, INTERRUPTION OF BUSINESS, OR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY KIND (INCLUDING LOST PROFITS) REGARDLESS OF THE FORM OF ACTION WHETHER IN CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT PRODUCT LIABILITY OR OTHERWISE, EVEN IF ADOBE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. Some states or jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation or exclusion may not apply to you.
+command: create-formula --name Adobe\ Reader\ 19 http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/misc/FontPack1902120058_XtdAlf_Lang_DC.msi

--- a/Formulas/adobe_reader_20.yml
+++ b/Formulas/adobe_reader_20.yml
@@ -21,14 +21,6 @@ fonts:
 - name: Courier Std
   styles:
   - family_name: Courier Std
-    type: Medium
-    full_name: CourierStd
-    post_script_name: CourierStd
-    version: 2.067;PS 2.000;hotconv 1.0.67;makeotf.lib2.5.33168
-    copyright: "© 1989, 1990, 1991, 1992, 1993, 1996, 1997, 1998, 2001 Adobe Systems
-      Incorporated. All rights reserved."
-    font: CourierStd.otf
-  - family_name: Courier Std
     type: Bold
     full_name: CourierStd-Bold
     post_script_name: CourierStd-Bold
@@ -37,7 +29,8 @@ fonts:
       Incorporated. All rights reserved."
     font: CourierStd_Bold.otf
   - family_name: Courier Std
-    type: Bold Oblique
+    type: Bold Italic
+    preferred_type: Bold Oblique
     full_name: CourierStd-BoldOblique
     post_script_name: CourierStd-BoldOblique
     version: 2.067;PS 2.000;hotconv 1.0.67;makeotf.lib2.5.33168
@@ -45,13 +38,23 @@ fonts:
       Incorporated. All rights reserved."
     font: CourierStd_BoldOblique.otf
   - family_name: Courier Std
-    type: Medium Oblique
+    type: Italic
+    preferred_type: Medium Oblique
     full_name: CourierStd-Oblique
     post_script_name: CourierStd-Oblique
     version: 2.067;PS 2.000;hotconv 1.0.67;makeotf.lib2.5.33168
     copyright: "© 1989, 1990, 1991, 1992, 1993, 1996, 1997, 1998, 2001 Adobe Systems
       Incorporated. All rights reserved."
     font: CourierStd_Oblique.otf
+  - family_name: Courier Std
+    type: Regular
+    preferred_type: Medium
+    full_name: CourierStd
+    post_script_name: CourierStd
+    version: 2.067;PS 2.000;hotconv 1.0.67;makeotf.lib2.5.33168
+    copyright: "© 1989, 1990, 1991, 1992, 1993, 1996, 1997, 1998, 2001 Adobe Systems
+      Incorporated. All rights reserved."
+    font: CourierStd.otf
 - name: Minion Pro
   styles:
   - family_name: Minion Pro
@@ -129,10 +132,9 @@ fonts:
     copyright: "© 1992, 1994, 1997, 2000, 2004 Adobe Systems Incorporated. All rights
       reserved."
     font: MyriadPro_Regular.otf
-extract:
-- format: seven_zip
-- format: cab
-copyright: "© 2000, 2004, 2006 Adobe Systems Incorporated. All Rights Reserved."
+extract: {}
+copyright: "© 1992, 1994, 1997, 2000, 2004 Adobe Systems Incorporated. All rights
+  reserved."
 license_url: http://www.adobe.com/type/legal.html
 requires_license_agreement: |-
   Adobe End-User License Agreement
@@ -147,3 +149,4 @@ requires_license_agreement: |-
   DISCLAIMER OF WARRANTIES: YOU AGREE THAT ADOBE HAS MADE NO EXPRESS WARRANTIES TO YOU REGARDING THE SOFTWARE AND THAT THE SOFTWARE IS BEING PROVIDED TO YOU "AS IS" WITHOUT WARRANTY OF ANY KIND. ADOBE DISCLAIMS ALL WARRANTIES WITH REGARD TO THE SOFTWARE, EXPRESS OR IMPLIED, INCLUDING, WITHOUT LIMITATION, ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, MERCHANTABLE QUALITY, OR NONINFRINGEMENT OF THIRD-PARTY RIGHTS. Some states or jurisdictions do not allow the exclusion of implied warranties, so the above limitations may not apply to you.
 
   LIMIT OF LIABILITY: IN NO EVENT WILL ADOBE BE LIABLE TO YOU FOR ANY LOSS OF USE, INTERRUPTION OF BUSINESS, OR ANY DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY KIND (INCLUDING LOST PROFITS) REGARDLESS OF THE FORM OF ACTION WHETHER IN CONTRACT, TORT (INCLUDING NEGLIGENCE), STRICT PRODUCT LIABILITY OR OTHERWISE, EVEN IF ADOBE HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES. Some states or jurisdictions do not allow the exclusion or limitation of incidental or consequential damages, so the above limitation or exclusion may not apply to you.
+command: create-formula --name Adobe\ Reader\ 20 http://ardownload.adobe.com/pub/adobe/reader/win/AcrobatDC/2001220041/AcroRdrDC2001220041_en_US.exe

--- a/Formulas/cleartype.yml
+++ b/Formulas/cleartype.yml
@@ -20,40 +20,14 @@ font_collections:
   fonts:
   - name: Cambria
     styles:
-    - type: Regular
+    - family_name: Cambria
+      type: Regular
       full_name: Cambria
   - name: Cambria Math
     styles:
-    - type: Regular
+    - family_name: Cambria Math
+      type: Regular
       full_name: Cambria Math
-- filename: MEIRYO.TTC
-  fonts:
-  - name: Meiryo
-    styles:
-    - type: Regular
-      full_name: Meiryo
-    - type: Italic
-      full_name: Meiryo Italic
-  - name: Meiryo UI
-    styles:
-    - type: Regular
-      full_name: Meiryo UI
-    - type: Italic
-      full_name: Meiryo UI Italic
-- filename: MEIRYOB.TTC
-  fonts:
-  - name: Meiryo
-    styles:
-    - type: Bold
-      full_name: Meiryo Bold
-    - type: Bold Italic
-      full_name: Meiryo Bold Italic
-  - name: Meiryo UI
-    styles:
-    - type: Bold
-      full_name: Meiryo UI Bold
-    - type: Bold Italic
-      full_name: Meiryo UI Bold Italic
 fonts:
 - name: Cambria
   styles:

--- a/Formulas/comic.yml
+++ b/Formulas/comic.yml
@@ -10,7 +10,7 @@ resources:
     - http://sft.if.usp.br/msttcorefonts/comic32.exe
     sha256: 9c6df3feefde26d4e41d4a4fe5db2a89f9123a772594d7f59afd062625cd204e
 fonts:
-- name: Comic Sans
+- name: Comic Sans MS
   styles:
   - family_name: Comic Sans MS
     type: Bold
@@ -62,3 +62,4 @@ requires_license_agreement: |
   this page was last updated 28 July 1998
   © 1997 Microsoft Corporation. All rights reserved. Terms of use.
   comments to the MST group: ttwsite@microsoft.com
+command: create-formula https://gitlab.com/fontmirror/archive/-/raw/master/comic32.exe

--- a/Formulas/courier.yml
+++ b/Formulas/courier.yml
@@ -10,7 +10,7 @@ resources:
     - http://sft.if.usp.br/msttcorefonts/courie32.exe
     sha256: bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384
 fonts:
-- name: Courier
+- name: Courier New
   styles:
   - family_name: Courier New
     type: Regular
@@ -60,8 +60,10 @@ fonts:
     copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
       plc/Type Solutions Inc. 1990-1992. All Rights Reserved
     font: couri.ttf
-extract:
-  format: cab
+extract: {}
+copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+  plc/Type Solutions Inc. 1990-1992. All Rights Reserved
+license_url: http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   (from http://web.archive.org/web/20011222020409/http://www.microsoft.com/typography/fontpack/eula.htm)
   TrueType core fonts for the Web EULA
@@ -90,3 +92,4 @@ requires_license_agreement: |
   this page was last updated 28 July 1998
   © 1997 Microsoft Corporation. All rights reserved. Terms of use.
   comments to the MST group: ttwsite@microsoft.com
+command: create-formula https://gitlab.com/fontmirror/archive/-/raw/master/courie32.exe

--- a/Formulas/dengxian.yml
+++ b/Formulas/dengxian.yml
@@ -12,13 +12,6 @@ fonts:
 - name: DengXian
   styles:
   - family_name: DengXian
-    type: Regular
-    full_name: DengXian Regular
-    post_script_name: DengXian-Regular
-    version: '1.14'
-    copyright: Copyright(c) Beijing Founder Electronics Co.,Ltd.2012
-    font: DENG.TTF
-  - family_name: DengXian
     type: Bold
     full_name: DengXian Bold
     post_script_name: DengXian-Bold
@@ -26,16 +19,24 @@ fonts:
     copyright: Copyright(c) Beijing Founder Electronics Co.,Ltd.2012
     font: DENGB.TTF
   - family_name: DengXian
-    type: Light
+    type: Regular
+    full_name: DengXian Regular
+    post_script_name: DengXian-Regular
+    version: '1.14'
+    copyright: Copyright(c) Beijing Founder Electronics Co.,Ltd.2012
+    font: DENG.TTF
+- name: DengXian Light
+  styles:
+  - family_name: DengXian Light
+    type: Regular
+    preferred_family_name: DengXian
+    preferred_type: Light
     full_name: DengXian Light
     post_script_name: DengXian-Light
     version: '1.14'
     copyright: Copyright(c) Beijing Founder Electronics Co.,Ltd.2012
     font: DENGL.TTF
-extract:
-- format: exe
-- format: msi
-- format: cab
+extract: {}
 copyright: Copyright(c) Beijing Founder Electronics Co.,Ltd.2012
 requires_license_agreement: |-
   MICROSOFT SOFTWARE SUPPLEMENTAL LICENSE TERMS
@@ -51,3 +52,4 @@ requires_license_agreement: |-
   If you comply with these license terms, you have the rights below.
 
   1. SUPPORT SERVICES FOR SUPPLEMENT. Microsoft provides support services for this software as described at www.support.microsoft.com/common/international.aspx.
+command: create-formula https://download.microsoft.com/download/4/0/9/4094ABA6-1A50-4FFD-A8CC-846BD66573F0/eadengfontpack.exe

--- a/Formulas/eb_garamond.yml
+++ b/Formulas/eb_garamond.yml
@@ -7,73 +7,84 @@ resources:
     - https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-0.016.zip
     sha256: a0b77b405f55c10cff078787ef9d2389a9638e7604d53aa80207fe62e104c378
 fonts:
-- name: EB Garamond
+- name: EB Garamond 08
   styles:
-  - family_name: EB Garamond
-    type: '08 Italic'
-    full_name: EB Garamond 08 Italic
-    post_script_name: EBGaramond08-Italic
-    version: '0.016'
-    copyright: Created by Georg Duffner with FontForge
-    font: EBGaramond08-Italic.otf
-  - family_name: EB Garamond
-    type: '08 Regular'
-    full_name: EB Garamond 08 Regular
-    post_script_name: EBGaramond08-Regular
-    version: '0.016'
-    copyright: Created by Georg Duffner with FontForge
-    font: EBGaramond08-Regular.otf
-  - family_name: EB Garamond
-    type: 12 Italic
-    full_name: EB Garamond 12 Italic
-    post_script_name: EBGaramond12-Italic
-    version: '0.016'
-    copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
-    font: EBGaramond12-Italic.otf
-  - family_name: EB Garamond
-    type: 12 Regular
-    full_name: EB Garamond 12 Regular
-    post_script_name: EBGaramond12-Regular
-    version: '0.016'
-    copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
-    font: EBGaramond12-Regular.otf
-  - family_name: EB Garamond
-    type: '08 Italic'
+  - family_name: EB Garamond 08
+    type: Italic
+    preferred_family_name: EB Garamond
+    preferred_type: '08 Italic'
     full_name: EB Garamond 08 Italic
     post_script_name: EBGaramond08-Italic
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg Duffner with FontForge
     font: EBGaramond08-Italic.ttf
-  - family_name: EB Garamond
-    type: '08 Regular'
+  - family_name: EB Garamond 08
+    type: Italic
+    preferred_family_name: EB Garamond
+    preferred_type: '08 Italic'
+    full_name: EB Garamond 08 Italic
+    post_script_name: EBGaramond08-Italic
+    version: '0.016'
+    copyright: Created by Georg Duffner with FontForge
+    font: EBGaramond08-Italic.otf
+  - family_name: EB Garamond 08
+    type: Regular
+    preferred_family_name: EB Garamond
+    preferred_type: '08 Regular'
     full_name: EB Garamond 08 Regular
     post_script_name: EBGaramond08-Regular
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg Duffner with FontForge
     font: EBGaramond08-Regular.ttf
-  - family_name: EB Garamond
-    type: 12 Italic
+  - family_name: EB Garamond 08
+    type: Regular
+    preferred_family_name: EB Garamond
+    preferred_type: '08 Regular'
+    full_name: EB Garamond 08 Regular
+    post_script_name: EBGaramond08-Regular
+    version: '0.016'
+    copyright: Created by Georg Duffner with FontForge
+    font: EBGaramond08-Regular.otf
+- name: EB Garamond 12
+  styles:
+  - family_name: EB Garamond 12
+    type: Italic
+    preferred_family_name: EB Garamond
+    preferred_type: 12 Italic
     full_name: EB Garamond 12 Italic
     post_script_name: EBGaramond12-Italic
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
     font: EBGaramond12-Italic.ttf
-  - family_name: EB Garamond
-    type: 12 Regular
+  - family_name: EB Garamond 12
+    type: Italic
+    preferred_family_name: EB Garamond
+    preferred_type: 12 Italic
+    full_name: EB Garamond 12 Italic
+    post_script_name: EBGaramond12-Italic
+    version: '0.016'
+    copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
+    font: EBGaramond12-Italic.otf
+  - family_name: EB Garamond 12
+    type: Regular
+    preferred_family_name: EB Garamond
+    preferred_type: 12 Regular
     full_name: EB Garamond 12 Regular
     post_script_name: EBGaramond12-Regular
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
     font: EBGaramond12-Regular.ttf
-- name: EB Garamond 12 All SC
-  styles:
-  - family_name: EB Garamond 12 All SC
-    type: AllSC
-    full_name: EB Garamond 12 Regular All SmallCaps
-    post_script_name: EBGaramond12-AllSC
+  - family_name: EB Garamond 12
+    type: Regular
+    preferred_family_name: EB Garamond
+    preferred_type: 12 Regular
+    full_name: EB Garamond 12 Regular
+    post_script_name: EBGaramond12-Regular
     version: '0.016'
     copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
-    font: EBGaramond12-AllSC.otf
+    font: EBGaramond12-Regular.otf
+- name: EB Garamond 12 All SC
+  styles:
   - family_name: EB Garamond 12 All SC
     type: AllSC
     full_name: EB Garamond 12 Regular All SmallCaps
@@ -81,15 +92,15 @@ fonts:
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
     font: EBGaramond12-AllSC.ttf
+  - family_name: EB Garamond 12 All SC
+    type: AllSC
+    full_name: EB Garamond 12 Regular All SmallCaps
+    post_script_name: EBGaramond12-AllSC
+    version: '0.016'
+    copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
+    font: EBGaramond12-AllSC.otf
 - name: EB Garamond Initials
   styles:
-  - family_name: EB Garamond Initials
-    type: Regular
-    full_name: EB Garamond Initials
-    post_script_name: EBGaramondInitials
-    version: '0.016'
-    copyright: Created by Georg A. Duffner,,, with FontForge 2.0 (http://fontforge.sf.net)
-    font: EBGaramond-Initials.otf
   - family_name: EB Garamond Initials
     type: Regular
     full_name: EB Garamond Initials
@@ -97,15 +108,15 @@ fonts:
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg A. Duffner,,, with FontForge 2.0 (http://fontforge.sf.net)
     font: EBGaramond-Initials.ttf
-- name: EB Garamond Initials Fill1
-  styles:
-  - family_name: EB Garamond Initials Fill1
+  - family_name: EB Garamond Initials
     type: Regular
-    full_name: EB Garamond Initials Fill1
-    post_script_name: EBGaramondInitialsF1
+    full_name: EB Garamond Initials
+    post_script_name: EBGaramondInitials
     version: '0.016'
     copyright: Created by Georg A. Duffner,,, with FontForge 2.0 (http://fontforge.sf.net)
-    font: EBGaramond-InitialsF1.otf
+    font: EBGaramond-Initials.otf
+- name: EB Garamond Initials Fill1
+  styles:
   - family_name: EB Garamond Initials Fill1
     type: Regular
     full_name: EB Garamond Initials Fill1
@@ -113,15 +124,15 @@ fonts:
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg A. Duffner,,, with FontForge 2.0 (http://fontforge.sf.net)
     font: EBGaramond-InitialsF1.ttf
-- name: EB Garamond Initials Fill2
-  styles:
-  - family_name: EB Garamond Initials Fill2
+  - family_name: EB Garamond Initials Fill1
     type: Regular
-    full_name: EB Garamond Initials Fill2
-    post_script_name: EBGaramondInitialsF2
+    full_name: EB Garamond Initials Fill1
+    post_script_name: EBGaramondInitialsF1
     version: '0.016'
     copyright: Created by Georg A. Duffner,,, with FontForge 2.0 (http://fontforge.sf.net)
-    font: EBGaramond-InitialsF2.otf
+    font: EBGaramond-InitialsF1.otf
+- name: EB Garamond Initials Fill2
+  styles:
   - family_name: EB Garamond Initials Fill2
     type: Regular
     full_name: EB Garamond Initials Fill2
@@ -129,39 +140,56 @@ fonts:
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg A. Duffner,,, with FontForge 2.0 (http://fontforge.sf.net)
     font: EBGaramond-InitialsF2.ttf
-- name: EB Garamond SC
+  - family_name: EB Garamond Initials Fill2
+    type: Regular
+    full_name: EB Garamond Initials Fill2
+    post_script_name: EBGaramondInitialsF2
+    version: '0.016'
+    copyright: Created by Georg A. Duffner,,, with FontForge 2.0 (http://fontforge.sf.net)
+    font: EBGaramond-InitialsF2.otf
+- name: EB Garamond SC 08
   styles:
-  - family_name: EB Garamond SC
-    type: '08 Regular'
-    full_name: EB Garamond SmallCaps 08 Regular
-    post_script_name: EBGaramondSC08-Regular
-    version: '0.016'
-    copyright: Created by Georg Duffner with FontForge
-    font: EBGaramondSC08-Regular.otf
-  - family_name: EB Garamond SC
-    type: 12 Regular
-    full_name: EB Garamond SmallCaps 12 Regular
-    post_script_name: EBGaramondSC12-Regular
-    version: '0.016'
-    copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
-    font: EBGaramondSC12-Regular.otf
-  - family_name: EB Garamond SC
-    type: '08 Regular'
+  - family_name: EB Garamond SC 08
+    type: Regular
+    preferred_family_name: EB Garamond SC
+    preferred_type: '08 Regular'
     full_name: EB Garamond SmallCaps 08 Regular
     post_script_name: EBGaramondSC08-Regular
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg Duffner with FontForge
     font: EBGaramondSC08-Regular.ttf
-  - family_name: EB Garamond SC
-    type: 12 Regular
+  - family_name: EB Garamond SC 08
+    type: Regular
+    preferred_family_name: EB Garamond SC
+    preferred_type: '08 Regular'
+    full_name: EB Garamond SmallCaps 08 Regular
+    post_script_name: EBGaramondSC08-Regular
+    version: '0.016'
+    copyright: Created by Georg Duffner with FontForge
+    font: EBGaramondSC08-Regular.otf
+- name: EB Garamond SC 12
+  styles:
+  - family_name: EB Garamond SC 12
+    type: Regular
+    preferred_family_name: EB Garamond SC
+    preferred_type: 12 Regular
     full_name: EB Garamond SmallCaps 12 Regular
     post_script_name: EBGaramondSC12-Regular
     version: 0.016 ; ttfautohint (v0.97) -l 8 -r 50 -G 200 -x 0 -f dflt -w gGD
     copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
     font: EBGaramondSC12-Regular.ttf
-extract:
-  format: zip
-copyright: Created by Georg A. Duffner,,, with FontForge 2.0 (http://fontforge.sf.net)
+  - family_name: EB Garamond SC 12
+    type: Regular
+    preferred_family_name: EB Garamond SC
+    preferred_type: 12 Regular
+    full_name: EB Garamond SmallCaps 12 Regular
+    post_script_name: EBGaramondSC12-Regular
+    version: '0.016'
+    copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
+    font: EBGaramondSC12-Regular.otf
+extract: {}
+copyright: Created by Georg Duffner with FontForge 2.0 (http://fontforge.sf.net)
+license_url: http://scripts.sil.org/OFL
 open_license: |-
   Copyright (c) 2010-2013 Georg Duffner (http://www.georgduffner.at)
 
@@ -256,3 +284,4 @@ open_license: |-
   DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
   FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
   OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://bitbucket.org/georgd/eb-garamond/downloads/EBGaramond-0.016.zip

--- a/Formulas/fira_code.yml
+++ b/Formulas/fira_code.yml
@@ -18,49 +18,66 @@ fonts:
     copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
     font: FiraCode-Bold.ttf
   - family_name: Fira Code
-    type: Light
-    full_name: Fira Code Light
-    post_script_name: FiraCode-Light
-    version: '5.002'
-    copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
-    font: FiraCode-Light.ttf
-  - family_name: Fira Code
-    type: Medium
-    full_name: Fira Code Medium
-    post_script_name: FiraCode-Medium
-    version: '5.002'
-    copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
-    font: FiraCode-Medium.ttf
-  - family_name: Fira Code
     type: Regular
     full_name: Fira Code Regular
     post_script_name: FiraCode-Regular
     version: '5.002'
     copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
     font: FiraCode-Regular.ttf
-  - family_name: Fira Code
-    type: Retina
-    full_name: Fira Code Retina
-    post_script_name: FiraCode-Retina
-    version: '5.002'
-    copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
-    font: FiraCode-Retina.ttf
-  - family_name: Fira Code
-    type: SemiBold
-    full_name: Fira Code SemiBold
-    post_script_name: FiraCode-SemiBold
-    version: '5.002'
-    copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
-    font: FiraCode-SemiBold.ttf
-  - family_name: Fira Code
-    type: Light
+- name: Fira Code Light
+  styles:
+  - family_name: Fira Code Light
+    type: Regular
+    preferred_family_name: Fira Code
+    preferred_type: Light
     full_name: Fira Code Light
     post_script_name: FiraCode-Light
     version: '5.002'
     copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
     font: FiraCode-VF.ttf
-extract:
-  format: zip
+  - family_name: Fira Code Light
+    type: Regular
+    preferred_family_name: Fira Code
+    preferred_type: Light
+    full_name: Fira Code Light
+    post_script_name: FiraCode-Light
+    version: '5.002'
+    copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
+    font: FiraCode-Light.ttf
+- name: Fira Code Medium
+  styles:
+  - family_name: Fira Code Medium
+    type: Regular
+    preferred_family_name: Fira Code
+    preferred_type: Medium
+    full_name: Fira Code Medium
+    post_script_name: FiraCode-Medium
+    version: '5.002'
+    copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
+    font: FiraCode-Medium.ttf
+- name: Fira Code Retina
+  styles:
+  - family_name: Fira Code Retina
+    type: Regular
+    preferred_family_name: Fira Code
+    preferred_type: Retina
+    full_name: Fira Code Retina
+    post_script_name: FiraCode-Retina
+    version: '5.002'
+    copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
+    font: FiraCode-Retina.ttf
+- name: Fira Code SemiBold
+  styles:
+  - family_name: Fira Code SemiBold
+    type: Regular
+    preferred_family_name: Fira Code
+    preferred_type: SemiBold
+    full_name: Fira Code SemiBold
+    post_script_name: FiraCode-SemiBold
+    version: '5.002'
+    copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
+    font: FiraCode-SemiBold.ttf
+extract: {}
 copyright: Copyright 2014-2020 The Fira Code Project Authors (https://github.com/tonsky/FiraCode)
 license_url: http://scripts.sil.org/OFL
 open_license: |-
@@ -157,3 +174,4 @@ open_license: |-
   DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
   FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
   OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://github.com/tonsky/FiraCode/releases/download/5.2/Fira_Code_v5.2.zip

--- a/Formulas/lato.yml
+++ b/Formulas/lato.yml
@@ -11,54 +11,6 @@ fonts:
 - name: Lato
   styles:
   - family_name: Lato
-    type: Black
-    full_name: Lato Black
-    post_script_name: Lato-Black
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-Black.ttf
-  - family_name: Lato
-    type: Black Italic
-    full_name: Lato Black Italic
-    post_script_name: Lato-BlackItalic
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-BlackItalic.ttf
-  - family_name: Lato
     type: Bold
     full_name: Lato Bold
     post_script_name: Lato-Bold
@@ -107,102 +59,6 @@ fonts:
       1.1 (http://scripts.sil.org/OFL).
     font: Lato-BoldItalic.ttf
   - family_name: Lato
-    type: Hairline
-    full_name: Lato Hairline
-    post_script_name: Lato-Hairline
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-Hairline.ttf
-  - family_name: Lato
-    type: Hairline Italic
-    full_name: Lato Hairline Italic
-    post_script_name: Lato-HairlineItalic
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-HairlineItalic.ttf
-  - family_name: Lato
-    type: Heavy
-    full_name: Lato Heavy
-    post_script_name: Lato-Heavy
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-Heavy.ttf
-  - family_name: Lato
-    type: Heavy Italic
-    full_name: Lato Heavy Italic
-    post_script_name: Lato-HeavyItalic
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-HeavyItalic.ttf
-  - family_name: Lato
     type: Italic
     full_name: Lato Italic
     post_script_name: Lato-Italic
@@ -227,102 +83,6 @@ fonts:
       1.1 (http://scripts.sil.org/OFL).
     font: Lato-Italic.ttf
   - family_name: Lato
-    type: Light
-    full_name: Lato Light
-    post_script_name: Lato-Light
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-Light.ttf
-  - family_name: Lato
-    type: Light Italic
-    full_name: Lato Light Italic
-    post_script_name: Lato-LightItalic
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-LightItalic.ttf
-  - family_name: Lato
-    type: Medium
-    full_name: Lato Medium
-    post_script_name: Lato-Medium
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-Medium.ttf
-  - family_name: Lato
-    type: Medium Italic
-    full_name: Lato Medium Italic
-    post_script_name: Lato-MediumItalic
-    version: 2.015; 2015-08-06; http://www.latofonts.com/
-    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
-      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
-      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
-      priorities: it should seem quite "transparent" when used in body text but would
-      display some original traits when used in larger sizes. The classical proportions,
-      particularly visible in the uppercase, give the letterforms familiar harmony
-      and elegance. At the same time, its sleek sanserif look makes evident the fact
-      that Lato was designed in the 2010s, even though it does not follow any current
-      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
-      while the strong structure provides stability and seriousness. In 2013-2014,
-      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
-      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
-      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
-      The Lato fonts are available free of charge under the SIL Open Font License
-      from http://www.latofonts.com/'
-    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
-      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
-      1.1 (http://scripts.sil.org/OFL).
-    font: Lato-MediumItalic.ttf
-  - family_name: Lato
     type: Regular
     full_name: Lato Regular
     post_script_name: Lato-Regular
@@ -346,10 +106,14 @@ fonts:
       with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
       1.1 (http://scripts.sil.org/OFL).
     font: Lato-Regular.ttf
-  - family_name: Lato
-    type: Semibold
-    full_name: Lato Semibold
-    post_script_name: Lato-Semibold
+- name: Lato Black
+  styles:
+  - family_name: Lato Black
+    type: Italic
+    preferred_family_name: Lato
+    preferred_type: Black Italic
+    full_name: Lato Black Italic
+    post_script_name: Lato-BlackItalic
     version: 2.015; 2015-08-06; http://www.latofonts.com/
     description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
       extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
@@ -369,9 +133,255 @@ fonts:
     copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
       with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
       1.1 (http://scripts.sil.org/OFL).
-    font: Lato-Semibold.ttf
-  - family_name: Lato
-    type: Semibold Italic
+    font: Lato-BlackItalic.ttf
+  - family_name: Lato Black
+    type: Regular
+    preferred_family_name: Lato
+    preferred_type: Black
+    full_name: Lato Black
+    post_script_name: Lato-Black
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-Black.ttf
+- name: Lato Hairline
+  styles:
+  - family_name: Lato Hairline
+    type: Italic
+    preferred_family_name: Lato
+    preferred_type: Hairline Italic
+    full_name: Lato Hairline Italic
+    post_script_name: Lato-HairlineItalic
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-HairlineItalic.ttf
+  - family_name: Lato Hairline
+    type: Regular
+    preferred_family_name: Lato
+    preferred_type: Hairline
+    full_name: Lato Hairline
+    post_script_name: Lato-Hairline
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-Hairline.ttf
+- name: Lato Heavy
+  styles:
+  - family_name: Lato Heavy
+    type: Italic
+    preferred_family_name: Lato
+    preferred_type: Heavy Italic
+    full_name: Lato Heavy Italic
+    post_script_name: Lato-HeavyItalic
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-HeavyItalic.ttf
+  - family_name: Lato Heavy
+    type: Regular
+    preferred_family_name: Lato
+    preferred_type: Heavy
+    full_name: Lato Heavy
+    post_script_name: Lato-Heavy
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-Heavy.ttf
+- name: Lato Light
+  styles:
+  - family_name: Lato Light
+    type: Italic
+    preferred_family_name: Lato
+    preferred_type: Light Italic
+    full_name: Lato Light Italic
+    post_script_name: Lato-LightItalic
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-LightItalic.ttf
+  - family_name: Lato Light
+    type: Regular
+    preferred_family_name: Lato
+    preferred_type: Light
+    full_name: Lato Light
+    post_script_name: Lato-Light
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-Light.ttf
+- name: Lato Medium
+  styles:
+  - family_name: Lato Medium
+    type: Italic
+    preferred_family_name: Lato
+    preferred_type: Medium Italic
+    full_name: Lato Medium Italic
+    post_script_name: Lato-MediumItalic
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-MediumItalic.ttf
+  - family_name: Lato Medium
+    type: Regular
+    preferred_family_name: Lato
+    preferred_type: Medium
+    full_name: Lato Medium
+    post_script_name: Lato-Medium
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-Medium.ttf
+- name: Lato Semibold
+  styles:
+  - family_name: Lato Semibold
+    type: Italic
+    preferred_family_name: Lato
+    preferred_type: Semibold Italic
     full_name: Lato Semibold Italic
     post_script_name: Lato-SemiboldItalic
     version: 2.015; 2015-08-06; http://www.latofonts.com/
@@ -394,10 +404,12 @@ fonts:
       with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
       1.1 (http://scripts.sil.org/OFL).
     font: Lato-SemiboldItalic.ttf
-  - family_name: Lato
-    type: Thin
-    full_name: Lato Thin
-    post_script_name: Lato-Thin
+  - family_name: Lato Semibold
+    type: Regular
+    preferred_family_name: Lato
+    preferred_type: Semibold
+    full_name: Lato Semibold
+    post_script_name: Lato-Semibold
     version: 2.015; 2015-08-06; http://www.latofonts.com/
     description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
       extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
@@ -417,9 +429,13 @@ fonts:
     copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
       with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
       1.1 (http://scripts.sil.org/OFL).
-    font: Lato-Thin.ttf
-  - family_name: Lato
-    type: Thin Italic
+    font: Lato-Semibold.ttf
+- name: Lato Thin
+  styles:
+  - family_name: Lato Thin
+    type: Italic
+    preferred_family_name: Lato
+    preferred_type: Thin Italic
     full_name: Lato Thin Italic
     post_script_name: Lato-ThinItalic
     version: 2.015; 2015-08-06; http://www.latofonts.com/
@@ -442,8 +458,33 @@ fonts:
       with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
       1.1 (http://scripts.sil.org/OFL).
     font: Lato-ThinItalic.ttf
-extract:
-  format: zip
+  - family_name: Lato Thin
+    type: Regular
+    preferred_family_name: Lato
+    preferred_type: Thin
+    full_name: Lato Thin
+    post_script_name: Lato-Thin
+    version: 2.015; 2015-08-06; http://www.latofonts.com/
+    description: 'Lato is a sanserif typeface family designed in the Summer 2010 and
+      extended in the Summer 2013 by Warsaw-based designer Lukasz Dziedzic ("Lato"
+      means "Summer" in Polish). It tries to carefully balance some potentially conflicting
+      priorities: it should seem quite "transparent" when used in body text but would
+      display some original traits when used in larger sizes. The classical proportions,
+      particularly visible in the uppercase, give the letterforms familiar harmony
+      and elegance. At the same time, its sleek sanserif look makes evident the fact
+      that Lato was designed in the 2010s, even though it does not follow any current
+      trend. The semi-rounded details of the letters give Lato a feeling of warmth,
+      while the strong structure provides stability and seriousness. In 2013-2014,
+      the family was greatly extended (with the help of Adam Twardoch and Botio Nikoltchev)
+      to cover 3000+ glyphs over nine weights with italics. It now supports 100+ Latin-based
+      languages, 50+ Cyrillic-based languages as well as Greek and IPA phonetics.
+      The Lato fonts are available free of charge under the SIL Open Font License
+      from http://www.latofonts.com/'
+    copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
+      with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
+      1.1 (http://scripts.sil.org/OFL).
+    font: Lato-Thin.ttf
+extract: {}
 copyright: Copyright (c) 2011-2015 by tyPoland Lukasz Dziedzic (http://www.typoland.com/)
   with Reserved Font Name "Lato". Licensed under the SIL Open Font License, Version
   1.1 (http://scripts.sil.org/OFL).
@@ -543,3 +584,4 @@ open_license: |-
   DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
   FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
   OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://www.latofonts.com/download/lato2ofl-zip/

--- a/Formulas/montserrat.yml
+++ b/Formulas/montserrat.yml
@@ -10,107 +10,10 @@ fonts:
 - name: Montserrat
   styles:
   - family_name: Montserrat
-    type: Thin
-    full_name: Montserrat Thin
-    post_script_name: Montserrat-Thin
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-Thin.otf
-  - family_name: Montserrat
-    type: Thin Italic
-    full_name: Montserrat Thin Italic
-    post_script_name: Montserrat-ThinItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-ThinItalic.otf
-  - family_name: Montserrat
-    type: ExtraLight
-    full_name: Montserrat ExtraLight
-    post_script_name: Montserrat-ExtraLight
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-ExtraLight.otf
-  - family_name: Montserrat
-    type: ExtraLight Italic
-    full_name: Montserrat ExtraLight Italic
-    post_script_name: Montserrat-ExtraLightItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-ExtraLightItalic.otf
-  - family_name: Montserrat
-    type: Light
-    full_name: Montserrat Light
-    post_script_name: Montserrat-Light
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-Light.otf
-  - family_name: Montserrat
-    type: Light Italic
-    full_name: Montserrat Light Italic
-    post_script_name: Montserrat-LightItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-LightItalic.otf
-  - family_name: Montserrat
-    type: Regular
-    full_name: Montserrat Regular
-    post_script_name: Montserrat-Regular
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-Regular.otf
-  - family_name: Montserrat
-    type: Italic
-    full_name: Montserrat Italic
-    post_script_name: Montserrat-Italic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-Italic.otf
-  - family_name: Montserrat
-    type: Medium
-    full_name: Montserrat Medium
-    post_script_name: Montserrat-Medium
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-Medium.otf
-  - family_name: Montserrat
-    type: Medium Italic
-    full_name: Montserrat Medium Italic
-    post_script_name: Montserrat-MediumItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-MediumItalic.otf
-  - family_name: Montserrat
-    type: SemiBold
-    full_name: Montserrat SemiBold
-    post_script_name: Montserrat-SemiBold
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-SemiBold.otf
-  - family_name: Montserrat
-    type: SemiBold Italic
-    full_name: Montserrat SemiBold Italic
-    post_script_name: Montserrat-SemiBoldItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-SemiBoldItalic.otf
-  - family_name: Montserrat
     type: Bold
     full_name: Montserrat Bold
     post_script_name: Montserrat-Bold
     version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
     copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
     font: Montserrat-Bold.otf
   - family_name: Montserrat
@@ -118,145 +21,29 @@ fonts:
     full_name: Montserrat Bold Italic
     post_script_name: Montserrat-BoldItalic
     version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
     copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
     font: Montserrat-BoldItalic.otf
   - family_name: Montserrat
-    type: ExtraBold
-    full_name: Montserrat ExtraBold
-    post_script_name: Montserrat-ExtraBold
+    type: Italic
+    full_name: Montserrat Italic
+    post_script_name: Montserrat-Italic
     version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
     copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-ExtraBold.otf
+    font: Montserrat-Italic.otf
   - family_name: Montserrat
-    type: ExtraBold Italic
-    full_name: Montserrat ExtraBold Italic
-    post_script_name: Montserrat-ExtraBoldItalic
+    type: Regular
+    full_name: Montserrat Regular
+    post_script_name: Montserrat-Regular
     version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
     copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-ExtraBoldItalic.otf
-  - family_name: Montserrat
-    type: Black
-    full_name: Montserrat Black
-    post_script_name: Montserrat-Black
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-Black.otf
-  - family_name: Montserrat
-    type: Black Italic
-    full_name: Montserrat Black Italic
-    post_script_name: Montserrat-BlackItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: Montserrat-BlackItalic.otf
+    font: Montserrat-Regular.otf
 - name: Montserrat Alternates
   styles:
-  - family_name: Montserrat Alternates
-    type: Thin
-    full_name: Montserrat Alternates Thin
-    post_script_name: MontserratAlternates-Thin
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-Thin.otf
-  - family_name: Montserrat Alternates
-    type: Thin Italic
-    full_name: Montserrat Alternates Thin Italic
-    post_script_name: MontserratAlternates-ThinItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-ThinItalic.otf
-  - family_name: Montserrat Alternates
-    type: ExtraLight
-    full_name: Montserrat Alternates ExtraLight
-    post_script_name: MontserratAlternates-ExtraLight
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-ExtraLight.otf
-  - family_name: Montserrat Alternates
-    type: ExtraLight Italic
-    full_name: Montserrat Alternates ExtraLight Italic
-    post_script_name: MontserratAlternates-ExtraLightItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-ExtraLightItalic.otf
-  - family_name: Montserrat Alternates
-    type: Light
-    full_name: Montserrat Alternates Light
-    post_script_name: MontserratAlternates-Light
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-Light.otf
-  - family_name: Montserrat Alternates
-    type: Light Italic
-    full_name: Montserrat Alternates Light Italic
-    post_script_name: MontserratAlternates-LightItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-LightItalic.otf
-  - family_name: Montserrat Alternates
-    type: Regular
-    full_name: Montserrat Alternates Regular
-    post_script_name: MontserratAlternates-Regular
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-Regular.otf
-  - family_name: Montserrat Alternates
-    type: Italic
-    full_name: Montserrat Alternates Italic
-    post_script_name: MontserratAlternates-Italic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-Italic.otf
-  - family_name: Montserrat Alternates
-    type: Medium
-    full_name: Montserrat Alternates Medium
-    post_script_name: MontserratAlternates-Medium
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-Medium.otf
-  - family_name: Montserrat Alternates
-    type: Medium Italic
-    full_name: Montserrat Alternates Medium Italic
-    post_script_name: MontserratAlternates-MediumItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-MediumItalic.otf
-  - family_name: Montserrat Alternates
-    type: SemiBold
-    full_name: Montserrat Alternates SemiBold
-    post_script_name: MontserratAlternates-SemiBold
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-SemiBold.otf
-  - family_name: Montserrat Alternates
-    type: SemiBold Italic
-    full_name: Montserrat Alternates SemiBold Italic
-    post_script_name: MontserratAlternates-SemiBoldItalic
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-SemiBoldItalic.otf
   - family_name: Montserrat Alternates
     type: Bold
     full_name: Montserrat Alternates Bold
     post_script_name: MontserratAlternates-Bold
     version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
     copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
     font: MontserratAlternates-Bold.otf
   - family_name: Montserrat Alternates
@@ -264,43 +51,305 @@ fonts:
     full_name: Montserrat Alternates Bold Italic
     post_script_name: MontserratAlternates-BoldItalic
     version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
     copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
     font: MontserratAlternates-BoldItalic.otf
   - family_name: Montserrat Alternates
-    type: ExtraBold
-    full_name: Montserrat Alternates ExtraBold
-    post_script_name: MontserratAlternates-ExtraBold
+    type: Italic
+    full_name: Montserrat Alternates Italic
+    post_script_name: MontserratAlternates-Italic
     version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
     copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-ExtraBold.otf
+    font: MontserratAlternates-Italic.otf
   - family_name: Montserrat Alternates
-    type: ExtraBold Italic
-    full_name: Montserrat Alternates ExtraBold Italic
-    post_script_name: MontserratAlternates-ExtraBoldItalic
+    type: Regular
+    full_name: Montserrat Alternates Regular
+    post_script_name: MontserratAlternates-Regular
     version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
     copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-ExtraBoldItalic.otf
-  - family_name: Montserrat Alternates
-    type: Black
-    full_name: Montserrat Alternates Black
-    post_script_name: MontserratAlternates-Black
-    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
-    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
-    font: MontserratAlternates-Black.otf
-  - family_name: Montserrat Alternates
-    type: Black Italic
+    font: MontserratAlternates-Regular.otf
+- name: Montserrat Alternates Black
+  styles:
+  - family_name: Montserrat Alternates Black
+    type: Italic
+    preferred_family_name: Montserrat Alternates
+    preferred_type: Black Italic
     full_name: Montserrat Alternates Black Italic
     post_script_name: MontserratAlternates-BlackItalic
     version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
-    description:
     copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
     font: MontserratAlternates-BlackItalic.otf
-extract:
-  format: zip
+  - family_name: Montserrat Alternates Black
+    type: Regular
+    preferred_family_name: Montserrat Alternates
+    preferred_type: Black
+    full_name: Montserrat Alternates Black
+    post_script_name: MontserratAlternates-Black
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-Black.otf
+- name: Montserrat Alternates ExLight
+  styles:
+  - family_name: Montserrat Alternates ExLight
+    type: Italic
+    preferred_family_name: Montserrat Alternates
+    preferred_type: ExtraLight Italic
+    full_name: Montserrat Alternates ExtraLight Italic
+    post_script_name: MontserratAlternates-ExtraLightItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-ExtraLightItalic.otf
+  - family_name: Montserrat Alternates ExLight
+    type: Regular
+    preferred_family_name: Montserrat Alternates
+    preferred_type: ExtraLight
+    full_name: Montserrat Alternates ExtraLight
+    post_script_name: MontserratAlternates-ExtraLight
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-ExtraLight.otf
+- name: Montserrat Alternates ExtraBold
+  styles:
+  - family_name: Montserrat Alternates ExtraBold
+    type: Italic
+    preferred_family_name: Montserrat Alternates
+    preferred_type: ExtraBold Italic
+    full_name: Montserrat Alternates ExtraBold Italic
+    post_script_name: MontserratAlternates-ExtraBoldItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-ExtraBoldItalic.otf
+  - family_name: Montserrat Alternates ExtraBold
+    type: Regular
+    preferred_family_name: Montserrat Alternates
+    preferred_type: ExtraBold
+    full_name: Montserrat Alternates ExtraBold
+    post_script_name: MontserratAlternates-ExtraBold
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-ExtraBold.otf
+- name: Montserrat Alternates Light
+  styles:
+  - family_name: Montserrat Alternates Light
+    type: Italic
+    preferred_family_name: Montserrat Alternates
+    preferred_type: Light Italic
+    full_name: Montserrat Alternates Light Italic
+    post_script_name: MontserratAlternates-LightItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-LightItalic.otf
+  - family_name: Montserrat Alternates Light
+    type: Regular
+    preferred_family_name: Montserrat Alternates
+    preferred_type: Light
+    full_name: Montserrat Alternates Light
+    post_script_name: MontserratAlternates-Light
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-Light.otf
+- name: Montserrat Alternates Medium
+  styles:
+  - family_name: Montserrat Alternates Medium
+    type: Italic
+    preferred_family_name: Montserrat Alternates
+    preferred_type: Medium Italic
+    full_name: Montserrat Alternates Medium Italic
+    post_script_name: MontserratAlternates-MediumItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-MediumItalic.otf
+  - family_name: Montserrat Alternates Medium
+    type: Regular
+    preferred_family_name: Montserrat Alternates
+    preferred_type: Medium
+    full_name: Montserrat Alternates Medium
+    post_script_name: MontserratAlternates-Medium
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-Medium.otf
+- name: Montserrat Alternates SemiBold
+  styles:
+  - family_name: Montserrat Alternates SemiBold
+    type: Italic
+    preferred_family_name: Montserrat Alternates
+    preferred_type: SemiBold Italic
+    full_name: Montserrat Alternates SemiBold Italic
+    post_script_name: MontserratAlternates-SemiBoldItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-SemiBoldItalic.otf
+  - family_name: Montserrat Alternates SemiBold
+    type: Regular
+    preferred_family_name: Montserrat Alternates
+    preferred_type: SemiBold
+    full_name: Montserrat Alternates SemiBold
+    post_script_name: MontserratAlternates-SemiBold
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-SemiBold.otf
+- name: Montserrat Alternates Thin
+  styles:
+  - family_name: Montserrat Alternates Thin
+    type: Italic
+    preferred_family_name: Montserrat Alternates
+    preferred_type: Thin Italic
+    full_name: Montserrat Alternates Thin Italic
+    post_script_name: MontserratAlternates-ThinItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-ThinItalic.otf
+  - family_name: Montserrat Alternates Thin
+    type: Regular
+    preferred_family_name: Montserrat Alternates
+    preferred_type: Thin
+    full_name: Montserrat Alternates Thin
+    post_script_name: MontserratAlternates-Thin
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: MontserratAlternates-Thin.otf
+- name: Montserrat Black
+  styles:
+  - family_name: Montserrat Black
+    type: Italic
+    preferred_family_name: Montserrat
+    preferred_type: Black Italic
+    full_name: Montserrat Black Italic
+    post_script_name: Montserrat-BlackItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-BlackItalic.otf
+  - family_name: Montserrat Black
+    type: Regular
+    preferred_family_name: Montserrat
+    preferred_type: Black
+    full_name: Montserrat Black
+    post_script_name: Montserrat-Black
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-Black.otf
+- name: Montserrat ExtraBold
+  styles:
+  - family_name: Montserrat ExtraBold
+    type: Italic
+    preferred_family_name: Montserrat
+    preferred_type: ExtraBold Italic
+    full_name: Montserrat ExtraBold Italic
+    post_script_name: Montserrat-ExtraBoldItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-ExtraBoldItalic.otf
+  - family_name: Montserrat ExtraBold
+    type: Regular
+    preferred_family_name: Montserrat
+    preferred_type: ExtraBold
+    full_name: Montserrat ExtraBold
+    post_script_name: Montserrat-ExtraBold
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-ExtraBold.otf
+- name: Montserrat ExtraLight
+  styles:
+  - family_name: Montserrat ExtraLight
+    type: Italic
+    preferred_family_name: Montserrat
+    preferred_type: ExtraLight Italic
+    full_name: Montserrat ExtraLight Italic
+    post_script_name: Montserrat-ExtraLightItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-ExtraLightItalic.otf
+  - family_name: Montserrat ExtraLight
+    type: Regular
+    preferred_family_name: Montserrat
+    preferred_type: ExtraLight
+    full_name: Montserrat ExtraLight
+    post_script_name: Montserrat-ExtraLight
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-ExtraLight.otf
+- name: Montserrat Light
+  styles:
+  - family_name: Montserrat Light
+    type: Italic
+    preferred_family_name: Montserrat
+    preferred_type: Light Italic
+    full_name: Montserrat Light Italic
+    post_script_name: Montserrat-LightItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-LightItalic.otf
+  - family_name: Montserrat Light
+    type: Regular
+    preferred_family_name: Montserrat
+    preferred_type: Light
+    full_name: Montserrat Light
+    post_script_name: Montserrat-Light
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-Light.otf
+- name: Montserrat Medium
+  styles:
+  - family_name: Montserrat Medium
+    type: Italic
+    preferred_family_name: Montserrat
+    preferred_type: Medium Italic
+    full_name: Montserrat Medium Italic
+    post_script_name: Montserrat-MediumItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-MediumItalic.otf
+  - family_name: Montserrat Medium
+    type: Regular
+    preferred_family_name: Montserrat
+    preferred_type: Medium
+    full_name: Montserrat Medium
+    post_script_name: Montserrat-Medium
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-Medium.otf
+- name: Montserrat SemiBold
+  styles:
+  - family_name: Montserrat SemiBold
+    type: Italic
+    preferred_family_name: Montserrat
+    preferred_type: SemiBold Italic
+    full_name: Montserrat SemiBold Italic
+    post_script_name: Montserrat-SemiBoldItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-SemiBoldItalic.otf
+  - family_name: Montserrat SemiBold
+    type: Regular
+    preferred_family_name: Montserrat
+    preferred_type: SemiBold
+    full_name: Montserrat SemiBold
+    post_script_name: Montserrat-SemiBold
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-SemiBold.otf
+- name: Montserrat Thin
+  styles:
+  - family_name: Montserrat Thin
+    type: Italic
+    preferred_family_name: Montserrat
+    preferred_type: Thin Italic
+    full_name: Montserrat Thin Italic
+    post_script_name: Montserrat-ThinItalic
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-ThinItalic.otf
+  - family_name: Montserrat Thin
+    type: Regular
+    preferred_family_name: Montserrat
+    preferred_type: Thin
+    full_name: Montserrat Thin
+    post_script_name: Montserrat-Thin
+    version: 7.200;PS 007.200;hotconv 1.0.88;makeotf.lib2.5.64775
+    copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+    font: Montserrat-Thin.otf
+extract: {}
+copyright: Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
+license_url: http://scripts.sil.org/OFL
 open_license: |+
   Copyright 2011 The Montserrat Project Authors (https://github.com/JulietaUla/Montserrat)
 
@@ -347,3 +396,4 @@ open_license: |+
   THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM OTHER DEALINGS IN THE FONT SOFTWARE.
 
 ...
+command: create-formula https://www.fontsquirrel.com/fonts/download/montserrat

--- a/Formulas/open_sans.yml
+++ b/Formulas/open_sans.yml
@@ -7,62 +7,13 @@ resources:
     urls:
     - https://www.fontsquirrel.com/fonts/download/open-sans
 fonts:
-- name: OpenSans
+- name: Open Sans
   styles:
-  - family_name: Open Sans
-    type: Light
-    full_name: Open Sans Light
-    post_script_name: OpenSans-Light
-    version: '1.10'
-    description:
-    copyright: Digitized data copyright © 2010-2011, Google Corporation.
-    font: OpenSans-Light.ttf
-  - family_name: Open Sans
-    type: Light Italic
-    full_name: Open Sans Light Italic
-    post_script_name: OpenSansLight-Italic
-    version: '1.10'
-    description:
-    copyright: Digitized data copyright © 2010-2011, Google Corporation.
-    font: OpenSans-LightItalic.ttf
-  - family_name: Open Sans
-    type: Regular
-    full_name: Open Sans
-    post_script_name: OpenSans
-    version: '1.10'
-    description:
-    copyright: Digitized data copyright © 2010-2011, Google Corporation.
-    font: OpenSans-Regular.ttf
-  - family_name: Open Sans
-    type: Italic
-    full_name: Open Sans Italic
-    post_script_name: OpenSans-Italic
-    version: '1.10'
-    description:
-    copyright: Digitized data copyright © 2010-2011, Google Corporation.
-    font: OpenSans-Italic.ttf
-  - family_name: Open Sans
-    type: Semibold
-    full_name: Open Sans Semibold
-    post_script_name: OpenSans-Semibold
-    version: '1.10'
-    description:
-    copyright: Digitized data copyright © 2011, Google Corporation.
-    font: OpenSans-Semibold.ttf
-  - family_name: Open Sans
-    type: Semibold Italic
-    full_name: Open Sans Semibold Italic
-    post_script_name: OpenSans-SemiboldItalic
-    version: '1.10'
-    description:
-    copyright: Digitized data copyright © 2010-2011, Google Corporation.
-    font: OpenSans-SemiboldItalic.ttf
   - family_name: Open Sans
     type: Bold
     full_name: Open Sans Bold
     post_script_name: OpenSans-Bold
     version: '1.10'
-    description:
     copyright: Digitized data copyright © 2010-2011, Google Corporation.
     font: OpenSans-Bold.ttf
   - family_name: Open Sans
@@ -70,27 +21,85 @@ fonts:
     full_name: Open Sans Bold Italic
     post_script_name: OpenSans-BoldItalic
     version: '1.10'
-    description:
     copyright: Digitized data copyright © 2010-2011, Google Corporation.
     font: OpenSans-BoldItalic.ttf
   - family_name: Open Sans
-    type: Extrabold
-    full_name: Open Sans Extrabold
-    post_script_name: OpenSans-Extrabold
+    type: Italic
+    full_name: Open Sans Italic
+    post_script_name: OpenSans-Italic
     version: '1.10'
-    description:
-    copyright: Digitized data copyright © 2011, Google Corporation.
-    font: OpenSans-ExtraBold.ttf
+    copyright: Digitized data copyright © 2010-2011, Google Corporation.
+    font: OpenSans-Italic.ttf
   - family_name: Open Sans
-    type: Extrabold Italic
+    type: Regular
+    full_name: Open Sans
+    post_script_name: OpenSans
+    version: '1.10'
+    copyright: Digitized data copyright © 2010-2011, Google Corporation.
+    font: OpenSans-Regular.ttf
+- name: Open Sans Extrabold
+  styles:
+  - family_name: Open Sans Extrabold
+    type: Italic
+    preferred_family_name: Open Sans
+    preferred_type: Extrabold Italic
     full_name: Open Sans Extrabold Italic
     post_script_name: OpenSans-ExtraboldItalic
     version: '1.10'
-    description:
     copyright: Digitized data copyright © 2010-2011, Google Corporation.
     font: OpenSans-ExtraBoldItalic.ttf
-extract:
-  format: zip
+  - family_name: Open Sans Extrabold
+    type: Regular
+    preferred_family_name: Open Sans
+    preferred_type: Extrabold
+    full_name: Open Sans Extrabold
+    post_script_name: OpenSans-Extrabold
+    version: '1.10'
+    copyright: Digitized data copyright © 2011, Google Corporation.
+    font: OpenSans-ExtraBold.ttf
+- name: Open Sans Light
+  styles:
+  - family_name: Open Sans Light
+    type: Italic
+    preferred_family_name: Open Sans
+    preferred_type: Light Italic
+    full_name: Open Sans Light Italic
+    post_script_name: OpenSansLight-Italic
+    version: '1.10'
+    copyright: Digitized data copyright © 2010-2011, Google Corporation.
+    font: OpenSans-LightItalic.ttf
+  - family_name: Open Sans Light
+    type: Regular
+    preferred_family_name: Open Sans
+    preferred_type: Light
+    full_name: Open Sans Light
+    post_script_name: OpenSans-Light
+    version: '1.10'
+    copyright: Digitized data copyright © 2010-2011, Google Corporation.
+    font: OpenSans-Light.ttf
+- name: Open Sans Semibold
+  styles:
+  - family_name: Open Sans Semibold
+    type: Italic
+    preferred_family_name: Open Sans
+    preferred_type: Semibold Italic
+    full_name: Open Sans Semibold Italic
+    post_script_name: OpenSans-SemiboldItalic
+    version: '1.10'
+    copyright: Digitized data copyright © 2010-2011, Google Corporation.
+    font: OpenSans-SemiboldItalic.ttf
+  - family_name: Open Sans Semibold
+    type: Regular
+    preferred_family_name: Open Sans
+    preferred_type: Semibold
+    full_name: Open Sans Semibold
+    post_script_name: OpenSans-Semibold
+    version: '1.10'
+    copyright: Digitized data copyright © 2011, Google Corporation.
+    font: OpenSans-Semibold.ttf
+extract: {}
+copyright: Digitized data copyright © 2011, Google Corporation.
+license_url: http://www.apache.org/licenses/LICENSE-2.0
 open_license: |
   Apache License
                              Version 2.0, January 2004
@@ -293,3 +302,4 @@ open_license: |
      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
      See the License for the specific language governing permissions and
      limitations under the License.
+command: create-formula https://www.fontsquirrel.com/fonts/download/open-sans

--- a/Formulas/overpass.yml
+++ b/Formulas/overpass.yml
@@ -11,15 +11,6 @@ fonts:
 - name: Overpass
   styles:
   - family_name: Overpass
-    type: Bold Italic
-    full_name: Overpass Bold Italic
-    post_script_name: Overpass-BoldItalic
-    version: 3.000;DELV;Overpass
-    description: Overpass is an open source webfont family inspired by Highway Gothic.
-      Sponsored by Red Hat and created by Delve Fonts.
-    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-bold-italic.otf
-  - family_name: Overpass
     type: Bold
     full_name: Overpass Bold
     post_script_name: Overpass-Bold
@@ -28,56 +19,14 @@ fonts:
     copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
     font: overpass-bold.otf
   - family_name: Overpass
-    type: ExtraBold Italic
-    full_name: Overpass ExtraBold Italic
-    post_script_name: Overpass-ExtraBoldItalic
+    type: Bold Italic
+    full_name: Overpass Bold Italic
+    post_script_name: Overpass-BoldItalic
     version: 3.000;DELV;Overpass
     description: Overpass is an open source webfont family inspired by Highway Gothic.
       Sponsored by Red Hat and created by Delve Fonts.
     copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-extrabold-italic.otf
-  - family_name: Overpass
-    type: ExtraBold
-    full_name: Overpass ExtraBold
-    post_script_name: Overpass-ExtraBold
-    version: 3.000;DELV;Overpass
-    description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
-    copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-extrabold.otf
-  - family_name: Overpass
-    type: ExtraLight
-    full_name: Overpass ExtraLight
-    post_script_name: Overpass-ExtraLight
-    version: 3.000;DELV;Overpass
-    description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
-    copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-extralight.otf
-  - family_name: Overpass
-    type: ExtraLight Italic
-    full_name: Overpass ExtraLight Italic
-    post_script_name: Overpass-ExtraLightItalic
-    version: 3.000;DELV;Overpass
-    description: Overpass is an open source webfont family inspired by Highway Gothic.
-      Sponsored by Red Hat and created by Delve Fonts.
-    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-extralight-italic.otf
-  - family_name: Overpass
-    type: Heavy Italic
-    full_name: Overpass Heavy Italic
-    post_script_name: Overpass-HeavyItalic
-    version: 3.000;DELV;Overpass
-    description: Overpass is an open source webfont family inspired by Highway Gothic.
-      Sponsored by Red Hat and created by Delve Fonts.
-    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-heavy-italic.otf
-  - family_name: Overpass
-    type: Heavy
-    full_name: Overpass Heavy
-    post_script_name: Overpass-Heavy
-    version: 3.000;DELV;Overpass
-    description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
-    copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-heavy.otf
+    font: overpass-bold-italic.otf
   - family_name: Overpass
     type: Italic
     full_name: Overpass Italic
@@ -88,23 +37,6 @@ fonts:
     copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
     font: overpass-italic.otf
   - family_name: Overpass
-    type: Light Italic
-    full_name: Overpass Light Italic
-    post_script_name: Overpass-LightItalic
-    version: 3.000;DELV;Overpass
-    description: Overpass is an open source webfont family inspired by Highway Gothic.
-      Sponsored by Red Hat and created by Delve Fonts.
-    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-light-italic.otf
-  - family_name: Overpass
-    type: Light
-    full_name: Overpass Light
-    post_script_name: Overpass-Light
-    version: 3.000;DELV;Overpass
-    description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
-    copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-light.otf
-  - family_name: Overpass
     type: Regular
     full_name: Overpass Regular
     post_script_name: Overpass-Regular
@@ -112,40 +44,108 @@ fonts:
     description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
     copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
     font: overpass-regular.otf
-  - family_name: Overpass
-    type: SemiBold Italic
-    full_name: Overpass SemiBold Italic
-    post_script_name: Overpass-SemiBoldItalic
+- name: Overpass ExtraBold
+  styles:
+  - family_name: Overpass ExtraBold
+    type: Italic
+    preferred_family_name: Overpass
+    preferred_type: ExtraBold Italic
+    full_name: Overpass ExtraBold Italic
+    post_script_name: Overpass-ExtraBoldItalic
     version: 3.000;DELV;Overpass
     description: Overpass is an open source webfont family inspired by Highway Gothic.
       Sponsored by Red Hat and created by Delve Fonts.
     copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-semibold-italic.otf
-  - family_name: Overpass
-    type: SemiBold
+    font: overpass-extrabold-italic.otf
+  - family_name: Overpass ExtraBold
+    type: Regular
+    preferred_family_name: Overpass
+    preferred_type: ExtraBold
+    full_name: Overpass ExtraBold
+    post_script_name: Overpass-ExtraBold
+    version: 3.000;DELV;Overpass
+    description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
+    copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
+    font: overpass-extrabold.otf
+- name: Overpass ExtraLight
+  styles:
+  - family_name: Overpass ExtraLight
+    type: Italic
+    preferred_family_name: Overpass
+    preferred_type: ExtraLight Italic
+    full_name: Overpass ExtraLight Italic
+    post_script_name: Overpass-ExtraLightItalic
+    version: 3.000;DELV;Overpass
+    description: Overpass is an open source webfont family inspired by Highway Gothic.
+      Sponsored by Red Hat and created by Delve Fonts.
+    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
+    font: overpass-extralight-italic.otf
+  - family_name: Overpass ExtraLight
+    type: Regular
+    preferred_family_name: Overpass
+    preferred_type: ExtraLight
+    full_name: Overpass ExtraLight
+    post_script_name: Overpass-ExtraLight
+    version: 3.000;DELV;Overpass
+    description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
+    copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
+    font: overpass-extralight.otf
+- name: Overpass Heavy
+  styles:
+  - family_name: Overpass Heavy
+    type: Italic
+    preferred_family_name: Overpass
+    preferred_type: Heavy Italic
+    full_name: Overpass Heavy Italic
+    post_script_name: Overpass-HeavyItalic
+    version: 3.000;DELV;Overpass
+    description: Overpass is an open source webfont family inspired by Highway Gothic.
+      Sponsored by Red Hat and created by Delve Fonts.
+    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
+    font: overpass-heavy-italic.otf
+  - family_name: Overpass Heavy
+    type: Regular
+    preferred_family_name: Overpass
+    preferred_type: Heavy
+    full_name: Overpass Heavy
+    post_script_name: Overpass-Heavy
+    version: 3.000;DELV;Overpass
+    description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
+    copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
+    font: overpass-heavy.otf
+- name: Overpass Light
+  styles:
+  - family_name: Overpass Light
+    type: Bold
+    preferred_family_name: Overpass
+    preferred_type: SemiBold
     full_name: Overpass SemiBold
     post_script_name: Overpass-SemiBold
     version: 3.000;DELV;Overpass
     description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
     copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
     font: overpass-semibold.otf
-  - family_name: Overpass
-    type: Thin Italic
-    full_name: Overpass Thin Italic
-    post_script_name: Overpass-ThinItalic
+  - family_name: Overpass Light
+    type: Italic
+    preferred_family_name: Overpass
+    preferred_type: Light Italic
+    full_name: Overpass Light Italic
+    post_script_name: Overpass-LightItalic
     version: 3.000;DELV;Overpass
     description: Overpass is an open source webfont family inspired by Highway Gothic.
       Sponsored by Red Hat and created by Delve Fonts.
     copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-thin-italic.otf
-  - family_name: Overpass
-    type: Thin
-    full_name: Overpass Thin
-    post_script_name: Overpass-Thin
+    font: overpass-light-italic.otf
+  - family_name: Overpass Light
+    type: Regular
+    preferred_family_name: Overpass
+    preferred_type: Light
+    full_name: Overpass Light
+    post_script_name: Overpass-Light
     version: 3.000;DELV;Overpass
     description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
     copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-thin.otf
+    font: overpass-light.otf
 - name: Overpass Mono
   styles:
   - family_name: Overpass Mono
@@ -166,17 +166,12 @@ fonts:
       Sponsored by Red Hat and created by Delve Fonts.
     copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
     font: overpass-mono-regular.otf
-  - family_name: Overpass Mono
-    type: Light
-    full_name: Overpass Mono Light
-    post_script_name: OverpassMono-Light
-    version: 1.000;DELV;Overpass
-    description: Overpass is an open source webfont family inspired by Highway Gothic.
-      Sponsored by Red Hat and created by Delve Fonts.
-    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
-    font: overpass-mono-light.otf
-  - family_name: Overpass Mono
-    type: SemiBold
+- name: Overpass Mono Light
+  styles:
+  - family_name: Overpass Mono Light
+    type: Bold
+    preferred_family_name: Overpass Mono
+    preferred_type: SemiBold
     full_name: Overpass Mono SemiBold
     post_script_name: OverpassMono-SemiBold
     version: 1.000;DELV;Overpass
@@ -184,13 +179,60 @@ fonts:
       Sponsored by Red Hat and created by Delve Fonts.
     copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
     font: overpass-mono-semibold.otf
-extract:
-  format: zip
-  options:
-    fonts_sub_dir: overpass**/
+  - family_name: Overpass Mono Light
+    type: Regular
+    preferred_family_name: Overpass Mono
+    preferred_type: Light
+    full_name: Overpass Mono Light
+    post_script_name: OverpassMono-Light
+    version: 1.000;DELV;Overpass
+    description: Overpass is an open source webfont family inspired by Highway Gothic.
+      Sponsored by Red Hat and created by Delve Fonts.
+    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
+    font: overpass-mono-light.otf
+- name: Overpass SemiBold
+  styles:
+  - family_name: Overpass SemiBold
+    type: Italic
+    preferred_family_name: Overpass
+    preferred_type: SemiBold Italic
+    full_name: Overpass SemiBold Italic
+    post_script_name: Overpass-SemiBoldItalic
+    version: 3.000;DELV;Overpass
+    description: Overpass is an open source webfont family inspired by Highway Gothic.
+      Sponsored by Red Hat and created by Delve Fonts.
+    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
+    font: overpass-semibold-italic.otf
+- name: Overpass Thin
+  styles:
+  - family_name: Overpass Thin
+    type: Italic
+    preferred_family_name: Overpass
+    preferred_type: Thin Italic
+    full_name: Overpass Thin Italic
+    post_script_name: Overpass-ThinItalic
+    version: 3.000;DELV;Overpass
+    description: Overpass is an open source webfont family inspired by Highway Gothic.
+      Sponsored by Red Hat and created by Delve Fonts.
+    copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
+    font: overpass-thin-italic.otf
+  - family_name: Overpass Thin
+    type: Regular
+    preferred_family_name: Overpass
+    preferred_type: Thin
+    full_name: Overpass Thin
+    post_script_name: Overpass-Thin
+    version: 3.000;DELV;Overpass
+    description: Copyright (c) 2011-2016 by Red Hat, Inc. All rights reserved.
+    copyright: Copyright © 2016 by Red Hat, Inc. All rights reserved.
+    font: overpass-thin.otf
+extract: {}
+copyright: Copyright (c) 2016 by Red Hat, Inc. All rights reserved.
+license_url: http://scripts.sil.org/cms/scripts/page.php?item_id=OFL_web  https://www.gnu.org/copyleft/lesser.html
 open_license: |+
   Copyright 2016 Red Hat, Inc.,
 
   This Font Software is dual licensed under the SIL Open Font License and the GNU Lesser General Public License, LGPL 2.1 : http://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html OFL 1.1 : http://scripts.sil.org/OFL
 
 ...
+command: create-formula https://github.com/RedHatOfficial/Overpass/releases/download/3.0.2/overpass-desktop-fonts.zip

--- a/Formulas/selawik.yml
+++ b/Formulas/selawik.yml
@@ -11,15 +11,6 @@ fonts:
 - name: Selawik
   styles:
   - family_name: Selawik
-    type: Regular
-    full_name: Selawik
-    post_script_name: Selawik-Regular
-    version: '1.01'
-    copyright: "© 2015 Microsoft Corporation (www.microsoft.com), with Reserved Font
-      Name Selawik. Selawik is a trademark of Microsoft Corporation in the United
-      States and/or other countries."
-    font: selawk.ttf
-  - family_name: Selawik
     type: Bold
     full_name: Selawik Bold
     post_script_name: Selawik-Bold
@@ -29,7 +20,20 @@ fonts:
       States and/or other countries."
     font: selawkb.ttf
   - family_name: Selawik
-    type: Light
+    type: Regular
+    full_name: Selawik
+    post_script_name: Selawik-Regular
+    version: '1.01'
+    copyright: "© 2015 Microsoft Corporation (www.microsoft.com), with Reserved Font
+      Name Selawik. Selawik is a trademark of Microsoft Corporation in the United
+      States and/or other countries."
+    font: selawk.ttf
+- name: Selawik Light
+  styles:
+  - family_name: Selawik Light
+    type: Regular
+    preferred_family_name: Selawik
+    preferred_type: Light
     full_name: Selawik Light
     post_script_name: Selawik-Light
     version: '1.01'
@@ -37,8 +41,12 @@ fonts:
       Name Selawik. Selawik is a trademark of Microsoft Corporation in the United
       States and/or other countries."
     font: selawkl.ttf
-  - family_name: Selawik
-    type: Semibold
+- name: Selawik Semibold
+  styles:
+  - family_name: Selawik Semibold
+    type: Regular
+    preferred_family_name: Selawik
+    preferred_type: Semibold
     full_name: Selawik Semibold
     post_script_name: Selawik-Semibold
     version: '1.01'
@@ -46,8 +54,12 @@ fonts:
       Name Selawik. Selawik is a trademark of Microsoft Corporation in the United
       States and/or other countries."
     font: selawksb.ttf
-  - family_name: Selawik
-    type: Semilight
+- name: Selawik Semilight
+  styles:
+  - family_name: Selawik Semilight
+    type: Regular
+    preferred_family_name: Selawik
+    preferred_type: Semilight
     full_name: Selawik Semilight
     post_script_name: Selawik-Semilight
     version: '1.01'
@@ -55,8 +67,7 @@ fonts:
       Name Selawik. Selawik is a trademark of Microsoft Corporation in the United
       States and/or other countries."
     font: selawksl.ttf
-extract:
-  format: zip
+extract: {}
 copyright: "© 2015 Microsoft Corporation (www.microsoft.com), with Reserved Font Name
   Selawik. Selawik is a trademark of Microsoft Corporation in the United States and/or
   other countries."
@@ -153,3 +164,4 @@ open_license: |-
   DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
   FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
   OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://github.com/microsoft/Selawik/releases/download/1.01/Selawik_Release.zip

--- a/Formulas/source.yml
+++ b/Formulas/source.yml
@@ -67,10 +67,12 @@ font_collections:
         Font Name 'Source'."
 - filename: SourceHanSans-ExtraLight.ttc
   fonts:
-  - name: Source Han Sans
+  - name: Source Han Sans ExtraLight
     styles:
-    - family_name: Source Han Sans
-      type: ExtraLight
+    - family_name: Source Han Sans ExtraLight
+      type: Regular
+      preferred_family_name: Source Han Sans
+      preferred_type: ExtraLight
       full_name: Source Han Sans ExtraLight
       post_script_name: SourceHanSans-ExtraLight
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -78,10 +80,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans HC
+  - name: Source Han Sans HC ExtraLight
     styles:
-    - family_name: Source Han Sans HC
-      type: ExtraLight
+    - family_name: Source Han Sans HC ExtraLight
+      type: Regular
+      preferred_family_name: Source Han Sans HC
+      preferred_type: ExtraLight
       full_name: Source Han Sans HC ExtraLight
       post_script_name: SourceHanSansHC-ExtraLight
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -89,10 +93,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans K
+  - name: Source Han Sans K ExtraLight
     styles:
-    - family_name: Source Han Sans K
-      type: ExtraLight
+    - family_name: Source Han Sans K ExtraLight
+      type: Regular
+      preferred_family_name: Source Han Sans K
+      preferred_type: ExtraLight
       full_name: Source Han Sans K ExtraLight
       post_script_name: SourceHanSansK-ExtraLight
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -100,10 +106,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans SC
+  - name: Source Han Sans SC ExtraLight
     styles:
-    - family_name: Source Han Sans SC
-      type: ExtraLight
+    - family_name: Source Han Sans SC ExtraLight
+      type: Regular
+      preferred_family_name: Source Han Sans SC
+      preferred_type: ExtraLight
       full_name: Source Han Sans SC ExtraLight
       post_script_name: SourceHanSansSC-ExtraLight
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -111,10 +119,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans TC
+  - name: Source Han Sans TC ExtraLight
     styles:
-    - family_name: Source Han Sans TC
-      type: ExtraLight
+    - family_name: Source Han Sans TC ExtraLight
+      type: Regular
+      preferred_family_name: Source Han Sans TC
+      preferred_type: ExtraLight
       full_name: Source Han Sans TC ExtraLight
       post_script_name: SourceHanSansTC-ExtraLight
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -124,21 +134,12 @@ font_collections:
         Font Name 'Source'."
 - filename: SourceHanSans-Heavy.ttc
   fonts:
-  - name: Source Han Sans
+  - name: Source Han Sans HC Heavy
     styles:
-    - family_name: Source Han Sans
-      type: Heavy
-      full_name: Source Han Sans Heavy
-      post_script_name: SourceHanSans-Heavy
-      version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
-      description: Dr. Ken Lunde (project architect, glyph set definition & overall
-        production); Masataka HATTORI 服部正貴 (production & ideograph elements)
-      copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
-        Font Name 'Source'."
-  - name: Source Han Sans HC
-    styles:
-    - family_name: Source Han Sans HC
-      type: Heavy
+    - family_name: Source Han Sans HC Heavy
+      type: Regular
+      preferred_family_name: Source Han Sans HC
+      preferred_type: Heavy
       full_name: Source Han Sans HC Heavy
       post_script_name: SourceHanSansHC-Heavy
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -146,10 +147,25 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans K
+  - name: Source Han Sans Heavy
     styles:
-    - family_name: Source Han Sans K
-      type: Heavy
+    - family_name: Source Han Sans Heavy
+      type: Regular
+      preferred_family_name: Source Han Sans
+      preferred_type: Heavy
+      full_name: Source Han Sans Heavy
+      post_script_name: SourceHanSans-Heavy
+      version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
+      description: Dr. Ken Lunde (project architect, glyph set definition & overall
+        production); Masataka HATTORI 服部正貴 (production & ideograph elements)
+      copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
+        Font Name 'Source'."
+  - name: Source Han Sans K Heavy
+    styles:
+    - family_name: Source Han Sans K Heavy
+      type: Regular
+      preferred_family_name: Source Han Sans K
+      preferred_type: Heavy
       full_name: Source Han Sans K Heavy
       post_script_name: SourceHanSansK-Heavy
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -157,10 +173,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans SC
+  - name: Source Han Sans SC Heavy
     styles:
-    - family_name: Source Han Sans SC
-      type: Heavy
+    - family_name: Source Han Sans SC Heavy
+      type: Regular
+      preferred_family_name: Source Han Sans SC
+      preferred_type: Heavy
       full_name: Source Han Sans SC Heavy
       post_script_name: SourceHanSansSC-Heavy
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -168,10 +186,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans TC
+  - name: Source Han Sans TC Heavy
     styles:
-    - family_name: Source Han Sans TC
-      type: Heavy
+    - family_name: Source Han Sans TC Heavy
+      type: Regular
+      preferred_family_name: Source Han Sans TC
+      preferred_type: Heavy
       full_name: Source Han Sans TC Heavy
       post_script_name: SourceHanSansTC-Heavy
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -181,21 +201,12 @@ font_collections:
         Font Name 'Source'."
 - filename: SourceHanSans-Light.ttc
   fonts:
-  - name: Source Han Sans
+  - name: Source Han Sans HC Light
     styles:
-    - family_name: Source Han Sans
-      type: Light
-      full_name: Source Han Sans Light
-      post_script_name: SourceHanSans-Light
-      version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
-      description: Dr. Ken Lunde (project architect, glyph set definition & overall
-        production); Masataka HATTORI 服部正貴 (production & ideograph elements)
-      copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
-        Font Name 'Source'."
-  - name: Source Han Sans HC
-    styles:
-    - family_name: Source Han Sans HC
-      type: Light
+    - family_name: Source Han Sans HC Light
+      type: Regular
+      preferred_family_name: Source Han Sans HC
+      preferred_type: Light
       full_name: Source Han Sans HC Light
       post_script_name: SourceHanSansHC-Light
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -203,10 +214,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans K
+  - name: Source Han Sans K Light
     styles:
-    - family_name: Source Han Sans K
-      type: Light
+    - family_name: Source Han Sans K Light
+      type: Regular
+      preferred_family_name: Source Han Sans K
+      preferred_type: Light
       full_name: Source Han Sans K Light
       post_script_name: SourceHanSansK-Light
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -214,10 +227,25 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans SC
+  - name: Source Han Sans Light
     styles:
-    - family_name: Source Han Sans SC
-      type: Light
+    - family_name: Source Han Sans Light
+      type: Regular
+      preferred_family_name: Source Han Sans
+      preferred_type: Light
+      full_name: Source Han Sans Light
+      post_script_name: SourceHanSans-Light
+      version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
+      description: Dr. Ken Lunde (project architect, glyph set definition & overall
+        production); Masataka HATTORI 服部正貴 (production & ideograph elements)
+      copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
+        Font Name 'Source'."
+  - name: Source Han Sans SC Light
+    styles:
+    - family_name: Source Han Sans SC Light
+      type: Regular
+      preferred_family_name: Source Han Sans SC
+      preferred_type: Light
       full_name: Source Han Sans SC Light
       post_script_name: SourceHanSansSC-Light
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -225,10 +253,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans TC
+  - name: Source Han Sans TC Light
     styles:
-    - family_name: Source Han Sans TC
-      type: Light
+    - family_name: Source Han Sans TC Light
+      type: Regular
+      preferred_family_name: Source Han Sans TC
+      preferred_type: Light
       full_name: Source Han Sans TC Light
       post_script_name: SourceHanSansTC-Light
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -238,21 +268,12 @@ font_collections:
         Font Name 'Source'."
 - filename: SourceHanSans-Medium.ttc
   fonts:
-  - name: Source Han Sans
+  - name: Source Han Sans HC Medium
     styles:
-    - family_name: Source Han Sans
-      type: Medium
-      full_name: Source Han Sans Medium
-      post_script_name: SourceHanSans-Medium
-      version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
-      description: Dr. Ken Lunde (project architect, glyph set definition & overall
-        production); Masataka HATTORI 服部正貴 (production & ideograph elements)
-      copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
-        Font Name 'Source'."
-  - name: Source Han Sans HC
-    styles:
-    - family_name: Source Han Sans HC
-      type: Medium
+    - family_name: Source Han Sans HC Medium
+      type: Regular
+      preferred_family_name: Source Han Sans HC
+      preferred_type: Medium
       full_name: Source Han Sans HC Medium
       post_script_name: SourceHanSansHC-Medium
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -260,10 +281,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans K
+  - name: Source Han Sans K Medium
     styles:
-    - family_name: Source Han Sans K
-      type: Medium
+    - family_name: Source Han Sans K Medium
+      type: Regular
+      preferred_family_name: Source Han Sans K
+      preferred_type: Medium
       full_name: Source Han Sans K Medium
       post_script_name: SourceHanSansK-Medium
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -271,10 +294,25 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans SC
+  - name: Source Han Sans Medium
     styles:
-    - family_name: Source Han Sans SC
-      type: Medium
+    - family_name: Source Han Sans Medium
+      type: Regular
+      preferred_family_name: Source Han Sans
+      preferred_type: Medium
+      full_name: Source Han Sans Medium
+      post_script_name: SourceHanSans-Medium
+      version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
+      description: Dr. Ken Lunde (project architect, glyph set definition & overall
+        production); Masataka HATTORI 服部正貴 (production & ideograph elements)
+      copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
+        Font Name 'Source'."
+  - name: Source Han Sans SC Medium
+    styles:
+    - family_name: Source Han Sans SC Medium
+      type: Regular
+      preferred_family_name: Source Han Sans SC
+      preferred_type: Medium
       full_name: Source Han Sans SC Medium
       post_script_name: SourceHanSansSC-Medium
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -282,10 +320,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans TC
+  - name: Source Han Sans TC Medium
     styles:
-    - family_name: Source Han Sans TC
-      type: Medium
+    - family_name: Source Han Sans TC Medium
+      type: Regular
+      preferred_family_name: Source Han Sans TC
+      preferred_type: Medium
       full_name: Source Han Sans TC Medium
       post_script_name: SourceHanSansTC-Medium
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -295,21 +335,12 @@ font_collections:
         Font Name 'Source'."
 - filename: SourceHanSans-Normal.ttc
   fonts:
-  - name: Source Han Sans
+  - name: Source Han Sans HC Normal
     styles:
-    - family_name: Source Han Sans
-      type: Normal
-      full_name: Source Han Sans Normal
-      post_script_name: SourceHanSans-Normal
-      version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
-      description: Dr. Ken Lunde (project architect, glyph set definition & overall
-        production); Masataka HATTORI 服部正貴 (production & ideograph elements)
-      copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
-        Font Name 'Source'."
-  - name: Source Han Sans HC
-    styles:
-    - family_name: Source Han Sans HC
-      type: Normal
+    - family_name: Source Han Sans HC Normal
+      type: Regular
+      preferred_family_name: Source Han Sans HC
+      preferred_type: Normal
       full_name: Source Han Sans HC Normal
       post_script_name: SourceHanSansHC-Normal
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -317,10 +348,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans K
+  - name: Source Han Sans K Normal
     styles:
-    - family_name: Source Han Sans K
-      type: Normal
+    - family_name: Source Han Sans K Normal
+      type: Regular
+      preferred_family_name: Source Han Sans K
+      preferred_type: Normal
       full_name: Source Han Sans K Normal
       post_script_name: SourceHanSansK-Normal
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -328,10 +361,25 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans SC
+  - name: Source Han Sans Normal
     styles:
-    - family_name: Source Han Sans SC
-      type: Normal
+    - family_name: Source Han Sans Normal
+      type: Regular
+      preferred_family_name: Source Han Sans
+      preferred_type: Normal
+      full_name: Source Han Sans Normal
+      post_script_name: SourceHanSans-Normal
+      version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
+      description: Dr. Ken Lunde (project architect, glyph set definition & overall
+        production); Masataka HATTORI 服部正貴 (production & ideograph elements)
+      copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
+        Font Name 'Source'."
+  - name: Source Han Sans SC Normal
+    styles:
+    - family_name: Source Han Sans SC Normal
+      type: Regular
+      preferred_family_name: Source Han Sans SC
+      preferred_type: Normal
       full_name: Source Han Sans SC Normal
       post_script_name: SourceHanSansSC-Normal
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -339,10 +387,12 @@ font_collections:
         production); Masataka HATTORI 服部正貴 (production & ideograph elements)
       copyright: "© 2014, 2015, 2018 Adobe (http://www.adobe.com/), with Reserved
         Font Name 'Source'."
-  - name: Source Han Sans TC
+  - name: Source Han Sans TC Normal
     styles:
-    - family_name: Source Han Sans TC
-      type: Normal
+    - family_name: Source Han Sans TC Normal
+      type: Regular
+      preferred_family_name: Source Han Sans TC
+      preferred_type: Normal
       full_name: Source Han Sans TC Normal
       post_script_name: SourceHanSansTC-Normal
       version: 2.000;hotconv 1.0.107;makeotfexe 2.5.65593
@@ -411,258 +461,276 @@ fonts:
 - name: Source Code Pro
   styles:
   - family_name: Source Code Pro
-    type: Regular
-    full_name: Source Code Pro
-    post_script_name: SourceCodePro-Regular
+    type: Bold
+    full_name: Source Code Pro Bold
+    post_script_name: SourceCodePro-Bold
     version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
     copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’.
-    font: SourceCodePro-Regular.ttf
-  - family_name: Source Code Pro
-    type: Medium Italic
-    full_name: Source Code Pro Medium Italic
-    post_script_name: SourceCodePro-MediumIt
-    version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
-    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’.
-    font: SourceCodePro-MediumIt.ttf
-  - family_name: Source Code Pro
-    type: Italic
-    full_name: Source Code Pro Italic
-    post_script_name: SourceCodePro-It
-    version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
-    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’.
-    font: SourceCodePro-It.ttf
-  - family_name: Source Code Pro
-    type: ExtraLight Italic
-    full_name: Source Code Pro ExtraLight Italic
-    post_script_name: SourceCodePro-ExtraLightIt
-    version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
-    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’.
-    font: SourceCodePro-ExtraLightIt.ttf
-  - family_name: Source Code Pro
-    type: ExtraLight
-    full_name: Source Code Pro ExtraLight
-    post_script_name: SourceCodePro-ExtraLight
-    version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
-    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’.
-    font: SourceCodePro-ExtraLight.ttf
-  - family_name: Source Code Pro
-    type: Black Italic
-    full_name: Source Code Pro Black Italic
-    post_script_name: SourceCodePro-BlackIt
-    version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
-    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’.
-    font: SourceCodePro-BlackIt.ttf
+    font: SourceCodePro-Bold.ttf
   - family_name: Source Code Pro
     type: Bold Italic
     full_name: Source Code Pro Bold Italic
     post_script_name: SourceCodePro-BoldIt
     version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
     copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’.
     font: SourceCodePro-BoldIt.ttf
   - family_name: Source Code Pro
-    type: Semibold Italic
-    full_name: Source Code Pro Semibold Italic
-    post_script_name: SourceCodePro-SemiboldIt
+    type: Italic
+    full_name: Source Code Pro Italic
+    post_script_name: SourceCodePro-It
     version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
     copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’.
-    font: SourceCodePro-SemiboldIt.ttf
+    font: SourceCodePro-It.ttf
   - family_name: Source Code Pro
-    type: Black
+    type: Regular
+    full_name: Source Code Pro
+    post_script_name: SourceCodePro-Regular
+    version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
+    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’.
+    font: SourceCodePro-Regular.ttf
+- name: Source Code Pro Black
+  styles:
+  - family_name: Source Code Pro Black
+    type: Italic
+    preferred_family_name: Source Code Pro
+    preferred_type: Black Italic
+    full_name: Source Code Pro Black Italic
+    post_script_name: SourceCodePro-BlackIt
+    version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
+    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’.
+    font: SourceCodePro-BlackIt.ttf
+  - family_name: Source Code Pro Black
+    type: Regular
+    preferred_family_name: Source Code Pro
+    preferred_type: Black
     full_name: Source Code Pro Black
     post_script_name: SourceCodePro-Black
     version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
     copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’.
     font: SourceCodePro-Black.ttf
-  - family_name: Source Code Pro
-    type: Bold
-    full_name: Source Code Pro Bold
-    post_script_name: SourceCodePro-Bold
-    version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
+- name: Source Code Pro ExtraLight
+  styles:
+  - family_name: Source Code Pro ExtraLight
+    type: Italic
+    preferred_family_name: Source Code Pro
+    preferred_type: ExtraLight Italic
+    full_name: Source Code Pro ExtraLight Italic
+    post_script_name: SourceCodePro-ExtraLightIt
+    version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
     copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’.
-    font: SourceCodePro-Bold.ttf
-  - family_name: Source Code Pro
-    type: Semibold
-    full_name: Source Code Pro Semibold
-    post_script_name: SourceCodePro-Semibold
+    font: SourceCodePro-ExtraLightIt.ttf
+  - family_name: Source Code Pro ExtraLight
+    type: Regular
+    preferred_family_name: Source Code Pro
+    preferred_type: ExtraLight
+    full_name: Source Code Pro ExtraLight
+    post_script_name: SourceCodePro-ExtraLight
     version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
     copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’.
-    font: SourceCodePro-Semibold.ttf
-  - family_name: Source Code Pro
-    type: Light Italic
+    font: SourceCodePro-ExtraLight.ttf
+- name: Source Code Pro Light
+  styles:
+  - family_name: Source Code Pro Light
+    type: Italic
+    preferred_family_name: Source Code Pro
+    preferred_type: Light Italic
     full_name: Source Code Pro Light Italic
     post_script_name: SourceCodePro-LightIt
     version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
     copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’.
     font: SourceCodePro-LightIt.ttf
-  - family_name: Source Code Pro
-    type: Medium
-    full_name: Source Code Pro Medium
-    post_script_name: SourceCodePro-Medium
-    version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
-    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’.
-    font: SourceCodePro-Medium.ttf
-  - family_name: Source Code Pro
-    type: Light
+  - family_name: Source Code Pro Light
+    type: Regular
+    preferred_family_name: Source Code Pro
+    preferred_type: Light
     full_name: Source Code Pro Light
     post_script_name: SourceCodePro-Light
     version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
-    description:
     copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’.
     font: SourceCodePro-Light.ttf
+- name: Source Code Pro Medium
+  styles:
+  - family_name: Source Code Pro Medium
+    type: Italic
+    preferred_family_name: Source Code Pro
+    preferred_type: Medium Italic
+    full_name: Source Code Pro Medium Italic
+    post_script_name: SourceCodePro-MediumIt
+    version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
+    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’.
+    font: SourceCodePro-MediumIt.ttf
+  - family_name: Source Code Pro Medium
+    type: Regular
+    preferred_family_name: Source Code Pro
+    preferred_type: Medium
+    full_name: Source Code Pro Medium
+    post_script_name: SourceCodePro-Medium
+    version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
+    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’.
+    font: SourceCodePro-Medium.ttf
+- name: Source Code Pro Semibold
+  styles:
+  - family_name: Source Code Pro Semibold
+    type: Italic
+    preferred_family_name: Source Code Pro
+    preferred_type: Semibold Italic
+    full_name: Source Code Pro Semibold Italic
+    post_script_name: SourceCodePro-SemiboldIt
+    version: 1.050;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
+    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’.
+    font: SourceCodePro-SemiboldIt.ttf
+  - family_name: Source Code Pro Semibold
+    type: Regular
+    preferred_family_name: Source Code Pro
+    preferred_type: Semibold
+    full_name: Source Code Pro Semibold
+    post_script_name: SourceCodePro-Semibold
+    version: 2.030;PS 1.000;hotconv 16.6.51;makeotf.lib2.5.65220
+    copyright: Copyright 2010, 2012 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’.
+    font: SourceCodePro-Semibold.ttf
 - name: Source Sans Pro
   styles:
-  - family_name: Source Sans Pro
-    type: Black Italic
-    full_name: Source Sans Pro Black Italic
-    post_script_name: SourceSansPro-BlackIt
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-BlackIt.ttf
-  - family_name: Source Sans Pro
-    type: Italic
-    full_name: Source Sans Pro Italic
-    post_script_name: SourceSansPro-It
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-It.ttf
-  - family_name: Source Sans Pro
-    type: Light
-    full_name: Source Sans Pro Light
-    post_script_name: SourceSansPro-Light
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-Light.ttf
-  - family_name: Source Sans Pro
-    type: ExtraLight
-    full_name: Source Sans Pro ExtraLight
-    post_script_name: SourceSansPro-ExtraLight
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-ExtraLight.ttf
-  - family_name: Source Sans Pro
-    type: ExtraLight Italic
-    full_name: Source Sans Pro ExtraLight Italic
-    post_script_name: SourceSansPro-ExtraLightIt
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-ExtraLightIt.ttf
-  - family_name: Source Sans Pro
-    type: Bold Italic
-    full_name: Source Sans Pro Bold Italic
-    post_script_name: SourceSansPro-BoldIt
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-BoldIt.ttf
-  - family_name: Source Sans Pro
-    type: Black
-    full_name: Source Sans Pro Black
-    post_script_name: SourceSansPro-Black
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-Black.ttf
-  - family_name: Source Sans Pro
-    type: Light Italic
-    full_name: Source Sans Pro Light Italic
-    post_script_name: SourceSansPro-LightIt
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-LightIt.ttf
-  - family_name: Source Sans Pro
-    type: Regular
-    full_name: Source Sans Pro
-    post_script_name: SourceSansPro-Regular
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-Regular.ttf
-  - family_name: Source Sans Pro
-    type: Semibold
-    full_name: Source Sans Pro Semibold
-    post_script_name: SourceSansPro-Semibold
-    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSansPro-Semibold.ttf
   - family_name: Source Sans Pro
     type: Bold
     full_name: Source Sans Pro Bold
     post_script_name: SourceSansPro-Bold
     version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
     copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’."
     font: SourceSansPro-Bold.ttf
   - family_name: Source Sans Pro
-    type: Semibold Italic
+    type: Bold Italic
+    full_name: Source Sans Pro Bold Italic
+    post_script_name: SourceSansPro-BoldIt
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-BoldIt.ttf
+  - family_name: Source Sans Pro
+    type: Italic
+    full_name: Source Sans Pro Italic
+    post_script_name: SourceSansPro-It
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-It.ttf
+  - family_name: Source Sans Pro
+    type: Regular
+    full_name: Source Sans Pro
+    post_script_name: SourceSansPro-Regular
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-Regular.ttf
+- name: Source Sans Pro Black
+  styles:
+  - family_name: Source Sans Pro Black
+    type: Italic
+    preferred_family_name: Source Sans Pro
+    preferred_type: Black Italic
+    full_name: Source Sans Pro Black Italic
+    post_script_name: SourceSansPro-BlackIt
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-BlackIt.ttf
+  - family_name: Source Sans Pro Black
+    type: Regular
+    preferred_family_name: Source Sans Pro
+    preferred_type: Black
+    full_name: Source Sans Pro Black
+    post_script_name: SourceSansPro-Black
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-Black.ttf
+- name: Source Sans Pro ExtraLight
+  styles:
+  - family_name: Source Sans Pro ExtraLight
+    type: Italic
+    preferred_family_name: Source Sans Pro
+    preferred_type: ExtraLight Italic
+    full_name: Source Sans Pro ExtraLight Italic
+    post_script_name: SourceSansPro-ExtraLightIt
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-ExtraLightIt.ttf
+  - family_name: Source Sans Pro ExtraLight
+    type: Regular
+    preferred_family_name: Source Sans Pro
+    preferred_type: ExtraLight
+    full_name: Source Sans Pro ExtraLight
+    post_script_name: SourceSansPro-ExtraLight
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-ExtraLight.ttf
+- name: Source Sans Pro Light
+  styles:
+  - family_name: Source Sans Pro Light
+    type: Italic
+    preferred_family_name: Source Sans Pro
+    preferred_type: Light Italic
+    full_name: Source Sans Pro Light Italic
+    post_script_name: SourceSansPro-LightIt
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-LightIt.ttf
+  - family_name: Source Sans Pro Light
+    type: Regular
+    preferred_family_name: Source Sans Pro
+    preferred_type: Light
+    full_name: Source Sans Pro Light
+    post_script_name: SourceSansPro-Light
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-Light.ttf
+- name: Source Sans Pro Semibold
+  styles:
+  - family_name: Source Sans Pro Semibold
+    type: Italic
+    preferred_family_name: Source Sans Pro
+    preferred_type: Semibold Italic
     full_name: Source Sans Pro Semibold Italic
     post_script_name: SourceSansPro-SemiboldIt
     version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
     copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’."
     font: SourceSansPro-SemiboldIt.ttf
+  - family_name: Source Sans Pro Semibold
+    type: Regular
+    preferred_family_name: Source Sans Pro
+    preferred_type: Semibold
+    full_name: Source Sans Pro Semibold
+    post_script_name: SourceSansPro-Semibold
+    version: 3.006;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSansPro-Semibold.ttf
 - name: Source Serif Pro
   styles:
-  - family_name: Source Serif Pro
-    type: Black
-    full_name: Source Serif Pro Black
-    post_script_name: SourceSerifPro-Black
-    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSerifPro-Black.ttf
   - family_name: Source Serif Pro
     type: Bold
     full_name: Source Serif Pro Bold
     post_script_name: SourceSerifPro-Bold
     version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
     copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’."
     font: SourceSerifPro-Bold.ttf
@@ -671,95 +739,117 @@ fonts:
     full_name: Source Serif Pro Bold Italic
     post_script_name: SourceSerifPro-BoldIt
     version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
     copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’."
     font: SourceSerifPro-BoldIt.ttf
-  - family_name: Source Serif Pro
-    type: Regular
-    full_name: Source Serif Pro
-    post_script_name: SourceSerifPro-Regular
-    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSerifPro-Regular.ttf
-  - family_name: Source Serif Pro
-    type: ExtraLight
-    full_name: Source Serif Pro ExtraLight
-    post_script_name: SourceSerifPro-ExtraLight
-    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSerifPro-ExtraLight.ttf
-  - family_name: Source Serif Pro
-    type: Semibold Italic
-    full_name: Source Serif Pro Semibold Italic
-    post_script_name: SourceSerifPro-SemiboldIt
-    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSerifPro-SemiboldIt.ttf
-  - family_name: Source Serif Pro
-    type: Black Italic
-    full_name: Source Serif Pro Black Italic
-    post_script_name: SourceSerifPro-BlackIt
-    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSerifPro-BlackIt.ttf
-  - family_name: Source Serif Pro
-    type: Semibold
-    full_name: Source Serif Pro Semibold
-    post_script_name: SourceSerifPro-Semibold
-    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSerifPro-Semibold.ttf
-  - family_name: Source Serif Pro
-    type: Light
-    full_name: Source Serif Pro Light
-    post_script_name: SourceSerifPro-Light
-    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSerifPro-Light.ttf
-  - family_name: Source Serif Pro
-    type: Light Italic
-    full_name: Source Serif Pro Light Italic
-    post_script_name: SourceSerifPro-LightIt
-    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSerifPro-LightIt.ttf
-  - family_name: Source Serif Pro
-    type: ExtraLight Italic
-    full_name: Source Serif Pro ExtraLight Italic
-    post_script_name: SourceSerifPro-ExtraLightIt
-    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
-    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
-      with Reserved Font Name ‘Source’."
-    font: SourceSerifPro-ExtraLightIt.ttf
   - family_name: Source Serif Pro
     type: Italic
     full_name: Source Serif Pro Italic
     post_script_name: SourceSerifPro-It
     version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
-    description:
     copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
       with Reserved Font Name ‘Source’."
     font: SourceSerifPro-It.ttf
-extract:
-  format: zip
-  options:
-    fonts_sub_dir: fonts/
+  - family_name: Source Serif Pro
+    type: Regular
+    full_name: Source Serif Pro
+    post_script_name: SourceSerifPro-Regular
+    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSerifPro-Regular.ttf
+- name: Source Serif Pro Black
+  styles:
+  - family_name: Source Serif Pro Black
+    type: Italic
+    preferred_family_name: Source Serif Pro
+    preferred_type: Black Italic
+    full_name: Source Serif Pro Black Italic
+    post_script_name: SourceSerifPro-BlackIt
+    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSerifPro-BlackIt.ttf
+  - family_name: Source Serif Pro Black
+    type: Regular
+    preferred_family_name: Source Serif Pro
+    preferred_type: Black
+    full_name: Source Serif Pro Black
+    post_script_name: SourceSerifPro-Black
+    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSerifPro-Black.ttf
+- name: Source Serif Pro ExtraLight
+  styles:
+  - family_name: Source Serif Pro ExtraLight
+    type: Italic
+    preferred_family_name: Source Serif Pro
+    preferred_type: ExtraLight Italic
+    full_name: Source Serif Pro ExtraLight Italic
+    post_script_name: SourceSerifPro-ExtraLightIt
+    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSerifPro-ExtraLightIt.ttf
+  - family_name: Source Serif Pro ExtraLight
+    type: Regular
+    preferred_family_name: Source Serif Pro
+    preferred_type: ExtraLight
+    full_name: Source Serif Pro ExtraLight
+    post_script_name: SourceSerifPro-ExtraLight
+    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSerifPro-ExtraLight.ttf
+- name: Source Serif Pro Light
+  styles:
+  - family_name: Source Serif Pro Light
+    type: Italic
+    preferred_family_name: Source Serif Pro
+    preferred_type: Light Italic
+    full_name: Source Serif Pro Light Italic
+    post_script_name: SourceSerifPro-LightIt
+    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSerifPro-LightIt.ttf
+  - family_name: Source Serif Pro Light
+    type: Regular
+    preferred_family_name: Source Serif Pro
+    preferred_type: Light
+    full_name: Source Serif Pro Light
+    post_script_name: SourceSerifPro-Light
+    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSerifPro-Light.ttf
+- name: Source Serif Pro Semibold
+  styles:
+  - family_name: Source Serif Pro Semibold
+    type: Italic
+    preferred_family_name: Source Serif Pro
+    preferred_type: Semibold Italic
+    full_name: Source Serif Pro Semibold Italic
+    post_script_name: SourceSerifPro-SemiboldIt
+    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSerifPro-SemiboldIt.ttf
+  - family_name: Source Serif Pro Semibold
+    type: Regular
+    preferred_family_name: Source Serif Pro
+    preferred_type: Semibold
+    full_name: Source Serif Pro Semibold
+    post_script_name: SourceSerifPro-Semibold
+    version: 3.001;hotconv 1.0.111;makeotfexe 2.5.65597
+    copyright: "© 2014 - 2019 Adobe Systems Incorporated (http://www.adobe.com/),
+      with Reserved Font Name ‘Source’."
+    font: SourceSerifPro-Semibold.ttf
+extract: {}
+copyright: "© 2010 - 2019 Adobe Systems Incorporated (http://www.adobe.com/), with
+  Reserved Font Name ‘Source’."
+license_url: http://scripts.sil.org/OFL
 open_license: |-
   Copyright 2010-2020 Adobe (http://www.adobe.com/), with Reserved Font Name 'Source'. All Rights Reserved. Source is a trademark of Adobe in the United States and/or other countries.
 
@@ -854,3 +944,4 @@ open_license: |-
   DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
   FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
   OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://github.com/fontist/source-fonts/releases/download/v1.0/source-fonts-1.0.zip

--- a/Formulas/stix.yml
+++ b/Formulas/stix.yml
@@ -65,32 +65,6 @@ fonts:
     copyright: Copyright 2001-2020 by the STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
     font: STIXTwoText-Italic.otf
   - family_name: STIX Two Text
-    type: Medium
-    full_name: STIX Two Text Medium
-    post_script_name: STIXTwoText-Medium
-    version: 2.10 b156
-    description: The Scientific and Technical Information eXchange (STIX) fonts are
-      intended to satisfy the demanding needs of authors, publishers, printers, and
-      others working in the scientific, medical, and technical fields. They combine
-      a comprehensive Unicode-based collection of mathematical symbols and alphabets
-      with a set of text faces suitable for professional publishing. The fonts are
-      available royalty-free under the SIL Open Font License.
-    copyright: Copyright 2001-2020 by the STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
-    font: STIXTwoText-Medium.otf
-  - family_name: STIX Two Text
-    type: Medium Italic
-    full_name: STIX Two Text Medium Italic
-    post_script_name: STIXTwoText-MediumItalic
-    version: 2.10 b156
-    description: The Scientific and Technical Information eXchange (STIX) fonts are
-      intended to satisfy the demanding needs of authors, publishers, printers, and
-      others working in the scientific, medical, and technical fields. They combine
-      a comprehensive Unicode-based collection of mathematical symbols and alphabets
-      with a set of text faces suitable for professional publishing. The fonts are
-      available royalty-free under the SIL Open Font License.
-    copyright: Copyright 2001-2020 by the STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
-    font: STIXTwoText-MediumItalic.otf
-  - family_name: STIX Two Text
     type: Regular
     full_name: STIX Two Text Regular
     post_script_name: STIXTwoText-Regular
@@ -103,10 +77,14 @@ fonts:
       available royalty-free under the SIL Open Font License.
     copyright: Copyright 2001-2020 by the STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
     font: STIXTwoText-Regular.otf
-  - family_name: STIX Two Text
-    type: Semibold
-    full_name: STIX Two Text Semibold
-    post_script_name: STIXTwoText-Semibold
+- name: STIX Two Text Medium
+  styles:
+  - family_name: STIX Two Text Medium
+    type: Italic
+    preferred_family_name: STIX Two Text
+    preferred_type: Medium Italic
+    full_name: STIX Two Text Medium Italic
+    post_script_name: STIXTwoText-MediumItalic
     version: 2.10 b156
     description: The Scientific and Technical Information eXchange (STIX) fonts are
       intended to satisfy the demanding needs of authors, publishers, printers, and
@@ -115,9 +93,28 @@ fonts:
       with a set of text faces suitable for professional publishing. The fonts are
       available royalty-free under the SIL Open Font License.
     copyright: Copyright 2001-2020 by the STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
-    font: STIXTwoText-Semibold.otf
-  - family_name: STIX Two Text
-    type: Semibold Italic
+    font: STIXTwoText-MediumItalic.otf
+  - family_name: STIX Two Text Medium
+    type: Regular
+    preferred_family_name: STIX Two Text
+    preferred_type: Medium
+    full_name: STIX Two Text Medium
+    post_script_name: STIXTwoText-Medium
+    version: 2.10 b156
+    description: The Scientific and Technical Information eXchange (STIX) fonts are
+      intended to satisfy the demanding needs of authors, publishers, printers, and
+      others working in the scientific, medical, and technical fields. They combine
+      a comprehensive Unicode-based collection of mathematical symbols and alphabets
+      with a set of text faces suitable for professional publishing. The fonts are
+      available royalty-free under the SIL Open Font License.
+    copyright: Copyright 2001-2020 by the STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
+    font: STIXTwoText-Medium.otf
+- name: STIX Two Text Semibold
+  styles:
+  - family_name: STIX Two Text Semibold
+    type: Italic
+    preferred_family_name: STIX Two Text
+    preferred_type: Semibold Italic
     full_name: STIX Two Text Semibold Italic
     post_script_name: STIXTwoText-SemiboldItalic
     version: 2.10 b156
@@ -129,8 +126,22 @@ fonts:
       available royalty-free under the SIL Open Font License.
     copyright: Copyright 2001-2020 by the STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
     font: STIXTwoText-SemiboldItalic.otf
+  - family_name: STIX Two Text Semibold
+    type: Regular
+    preferred_family_name: STIX Two Text
+    preferred_type: Semibold
+    full_name: STIX Two Text Semibold
+    post_script_name: STIXTwoText-Semibold
+    version: 2.10 b156
+    description: The Scientific and Technical Information eXchange (STIX) fonts are
+      intended to satisfy the demanding needs of authors, publishers, printers, and
+      others working in the scientific, medical, and technical fields. They combine
+      a comprehensive Unicode-based collection of mathematical symbols and alphabets
+      with a set of text faces suitable for professional publishing. The fonts are
+      available royalty-free under the SIL Open Font License.
+    copyright: Copyright 2001-2020 by the STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
+    font: STIXTwoText-Semibold.otf
 extract:
-  format: zip
   options:
     fonts_sub_dir: stixfonts-2.10/fonts/static_otf
 copyright: Copyright 2001-2020 by the STIX Fonts Project Authors (https://github.com/stipub/stixfonts)
@@ -244,3 +255,4 @@ open_license: |-
   DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
   FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
   OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula --subdir stixfonts-2.10/fonts/static_otf https://github.com/stipub/stixfonts/archive/v2.10.zip

--- a/Formulas/tex_gyre_chorus.yml
+++ b/Formulas/tex_gyre_chorus.yml
@@ -7,10 +7,11 @@ resources:
     - https://github.com/brechtm/rinoh-typeface-texgyrechorus/archive/v0.1.1.zip
     sha256: b38742b48440c66fc59b9bfc601019a398673bde8d7133520049e0571bc6b7f4
 fonts:
-- name: TeX Gyre Chorus
+- name: TeXGyreChorus
   styles:
-  - family_name: TeX Gyre Chorus
+  - family_name: TeXGyreChorus
     type: Regular
+    preferred_family_name: TeX Gyre Chorus
     full_name: TeXGyreChorus-MediumItalic
     post_script_name: TeXGyreChorus-MediumItalic
     version: 2.003;PS 2.003;hotconv 1.0.49;makeotf.lib2.0.14853
@@ -19,8 +20,7 @@ fonts:
       Font License --  see http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt for
       details.
     font: texgyrechorus-mediumitalic.otf
-extract:
-  format: zip
+extract: {}
 copyright: Copyright 2006, 2009 for TeX Gyre extensions by B. Jackowski and J.M. Nowacki
   (on behalf of TeX users groups). This work is released under the GUST Font License
   --  see http://tug.org/fonts/licenses/GUST-FONT-LICENSE.txt for details.
@@ -54,3 +54,4 @@ open_license: |-
   % The latest version of the LaTeX Project Public License is in
   % http://www.latex-project.org/lppl.txt and version 1.3c or later
   % is part of all distributions of LaTeX version 2006/05/20 or later.
+command: create-formula https://github.com/brechtm/rinoh-typeface-texgyrechorus/archive/v0.1.1.zip

--- a/Formulas/work_sans.yml
+++ b/Formulas/work_sans.yml
@@ -11,20 +11,6 @@ fonts:
 - name: Work Sans
   styles:
   - family_name: Work Sans
-    type: Black
-    full_name: Work Sans Black
-    post_script_name: WorkSans-Black
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-Black.ttf
-  - family_name: Work Sans
-    type: Black Italic
-    full_name: Work Sans Black Italic
-    post_script_name: WorkSans-BlackItalic
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-BlackItalic.ttf
-  - family_name: Work Sans
     type: Bold
     full_name: Work Sans Bold
     post_script_name: WorkSans-Bold
@@ -39,34 +25,6 @@ fonts:
     copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
     font: WorkSans-BoldItalic.ttf
   - family_name: Work Sans
-    type: ExtraBold
-    full_name: Work Sans ExtraBold
-    post_script_name: WorkSans-ExtraBold
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-ExtraBold.ttf
-  - family_name: Work Sans
-    type: ExtraBold Italic
-    full_name: Work Sans ExtraBold Italic
-    post_script_name: WorkSans-ExtraBoldItalic
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-ExtraBoldItalic.ttf
-  - family_name: Work Sans
-    type: ExtraLight
-    full_name: Work Sans ExtraLight
-    post_script_name: WorkSans-ExtraLight
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-ExtraLight.ttf
-  - family_name: Work Sans
-    type: ExtraLight Italic
-    full_name: Work Sans ExtraLight Italic
-    post_script_name: WorkSans-ExtraLightItalic
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-ExtraLightItalic.ttf
-  - family_name: Work Sans
     type: Italic
     full_name: Work Sans Italic
     post_script_name: WorkSans-Italic
@@ -74,76 +32,159 @@ fonts:
     copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
     font: WorkSans-Italic.ttf
   - family_name: Work Sans
-    type: Light
-    full_name: Work Sans Light
-    post_script_name: WorkSans-Light
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-Light.ttf
-  - family_name: Work Sans
-    type: Light Italic
-    full_name: Work Sans Light Italic
-    post_script_name: WorkSans-LightItalic
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-LightItalic.ttf
-  - family_name: Work Sans
-    type: Medium
-    full_name: Work Sans Medium
-    post_script_name: WorkSans-Medium
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-Medium.ttf
-  - family_name: Work Sans
-    type: Medium Italic
-    full_name: Work Sans Medium Italic
-    post_script_name: WorkSans-MediumItalic
-    version: 2.010; ttfautohint (v1.8.3)
-    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-MediumItalic.ttf
-  - family_name: Work Sans
     type: Regular
     full_name: Work Sans Regular
     post_script_name: WorkSans-Regular
     version: 2.010; ttfautohint (v1.8.3)
     copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
     font: WorkSans-Regular.ttf
-  - family_name: Work Sans
-    type: SemiBold
-    full_name: Work Sans SemiBold
-    post_script_name: WorkSans-SemiBold
+- name: Work Sans Black
+  styles:
+  - family_name: Work Sans Black
+    type: Italic
+    preferred_family_name: Work Sans
+    preferred_type: Black Italic
+    full_name: Work Sans Black Italic
+    post_script_name: WorkSans-BlackItalic
     version: 2.010; ttfautohint (v1.8.3)
     copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-SemiBold.ttf
-  - family_name: Work Sans
-    type: SemiBold Italic
+    font: WorkSans-BlackItalic.ttf
+  - family_name: Work Sans Black
+    type: Regular
+    preferred_family_name: Work Sans
+    preferred_type: Black
+    full_name: Work Sans Black
+    post_script_name: WorkSans-Black
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-Black.ttf
+- name: Work Sans ExtraBold
+  styles:
+  - family_name: Work Sans ExtraBold
+    type: Italic
+    preferred_family_name: Work Sans
+    preferred_type: ExtraBold Italic
+    full_name: Work Sans ExtraBold Italic
+    post_script_name: WorkSans-ExtraBoldItalic
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-ExtraBoldItalic.ttf
+  - family_name: Work Sans ExtraBold
+    type: Regular
+    preferred_family_name: Work Sans
+    preferred_type: ExtraBold
+    full_name: Work Sans ExtraBold
+    post_script_name: WorkSans-ExtraBold
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-ExtraBold.ttf
+- name: Work Sans ExtraLight
+  styles:
+  - family_name: Work Sans ExtraLight
+    type: Italic
+    preferred_family_name: Work Sans
+    preferred_type: ExtraLight Italic
+    full_name: Work Sans ExtraLight Italic
+    post_script_name: WorkSans-ExtraLightItalic
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-ExtraLightItalic.ttf
+  - family_name: Work Sans ExtraLight
+    type: Regular
+    preferred_family_name: Work Sans
+    preferred_type: ExtraLight
+    full_name: Work Sans ExtraLight
+    post_script_name: WorkSans-ExtraLight
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-ExtraLight.ttf
+- name: Work Sans Light
+  styles:
+  - family_name: Work Sans Light
+    type: Italic
+    preferred_family_name: Work Sans
+    preferred_type: Light Italic
+    full_name: Work Sans Light Italic
+    post_script_name: WorkSans-LightItalic
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-LightItalic.ttf
+  - family_name: Work Sans Light
+    type: Regular
+    preferred_family_name: Work Sans
+    preferred_type: Light
+    full_name: Work Sans Light
+    post_script_name: WorkSans-Light
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-Light.ttf
+- name: Work Sans Medium
+  styles:
+  - family_name: Work Sans Medium
+    type: Italic
+    preferred_family_name: Work Sans
+    preferred_type: Medium Italic
+    full_name: Work Sans Medium Italic
+    post_script_name: WorkSans-MediumItalic
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-MediumItalic.ttf
+  - family_name: Work Sans Medium
+    type: Regular
+    preferred_family_name: Work Sans
+    preferred_type: Medium
+    full_name: Work Sans Medium
+    post_script_name: WorkSans-Medium
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-Medium.ttf
+- name: Work Sans SemiBold
+  styles:
+  - family_name: Work Sans SemiBold
+    type: Italic
+    preferred_family_name: Work Sans
+    preferred_type: SemiBold Italic
     full_name: Work Sans SemiBold Italic
     post_script_name: WorkSans-SemiBoldItalic
     version: 2.010; ttfautohint (v1.8.3)
     copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
     font: WorkSans-SemiBoldItalic.ttf
-  - family_name: Work Sans
-    type: Thin
-    full_name: Work Sans Thin
-    post_script_name: WorkSans-Thin
+  - family_name: Work Sans SemiBold
+    type: Regular
+    preferred_family_name: Work Sans
+    preferred_type: SemiBold
+    full_name: Work Sans SemiBold
+    post_script_name: WorkSans-SemiBold
     version: 2.010; ttfautohint (v1.8.3)
     copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
-    font: WorkSans-Thin.ttf
-  - family_name: Work Sans
-    type: Thin Italic
+    font: WorkSans-SemiBold.ttf
+- name: Work Sans Thin
+  styles:
+  - family_name: Work Sans Thin
+    type: Italic
+    preferred_family_name: Work Sans
+    preferred_type: Thin Italic
     full_name: Work Sans Thin Italic
     post_script_name: WorkSans-ThinItalic
     version: 2.010; ttfautohint (v1.8.3)
     copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
     font: WorkSans-ThinItalic.ttf
+  - family_name: Work Sans Thin
+    type: Regular
+    preferred_family_name: Work Sans
+    preferred_type: Thin
+    full_name: Work Sans Thin
+    post_script_name: WorkSans-Thin
+    version: 2.010; ttfautohint (v1.8.3)
+    copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+    font: WorkSans-Thin.ttf
 extract:
-  format: zip
   options:
-    fonts_sub_dir: Work-Sans-2.010/fonts/static/*
+    fonts_sub_dir: Work-Sans-2.010/fonts/static/TTF
 copyright: Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
 license_url: http://scripts.sil.org/OFL
 open_license: |-
-  Copyright 2019 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
+  Copyright 2018 The Work Sans Project Authors (https://github.com/weiweihuanghuang/Work-Sans)
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.
   This license is copied below, and is also available with a FAQ at:
@@ -236,3 +277,4 @@ open_license: |-
   DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
   FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
   OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula --subdir Work-Sans-2.010/fonts/static/TTF https://github.com/weiweihuanghuang/Work-Sans/archive/v2.010.zip

--- a/Formulas/yu.yml
+++ b/Formulas/yu.yml
@@ -28,36 +28,46 @@ font_collections:
       post_script_name: YuGothicUI-Bold
       version: '1.10'
       copyright: Copyright © 2014 JIYUKOBO Ltd. All Rights Reserved.
-    - family_name: Yu Gothic UI
-      type: Semibold
+  - name: Yu Gothic UI Semibold
+    styles:
+    - family_name: Yu Gothic UI Semibold
+      type: Regular
+      preferred_family_name: Yu Gothic UI
+      preferred_type: Semibold
       full_name: Yu Gothic UI Semibold
       post_script_name: YuGothicUI-Semibold
       version: '1.10'
       copyright: Copyright © 2014 JIYUKOBO Ltd. All Rights Reserved.
 - filename: YUGOTHL.TTC
   fonts:
-  - name: Yu Gothic
+  - name: Yu Gothic Light
     styles:
-    - family_name: Yu Gothic
-      type: Light
+    - family_name: Yu Gothic Light
+      type: Regular
+      preferred_family_name: Yu Gothic
+      preferred_type: Light
       full_name: Yu Gothic Light
       post_script_name: YuGothic-Light
       version: '1.62'
       copyright: Copyright © 2014 JIYUKOBO Ltd. All Rights Reserved.
-  - name: Yu Gothic UI
+  - name: Yu Gothic UI Light
     styles:
-    - family_name: Yu Gothic UI
-      type: Light
+    - family_name: Yu Gothic UI Light
+      type: Regular
+      preferred_family_name: Yu Gothic UI
+      preferred_type: Light
       full_name: Yu Gothic UI Light
       post_script_name: YuGothicUI-Light
       version: '1.10'
       copyright: Copyright © 2014 JIYUKOBO Ltd. All Rights Reserved.
 - filename: YUGOTHM.TTC
   fonts:
-  - name: Yu Gothic
+  - name: Yu Gothic Medium
     styles:
-    - family_name: Yu Gothic
-      type: Medium
+    - family_name: Yu Gothic Medium
+      type: Regular
+      preferred_family_name: Yu Gothic
+      preferred_type: Medium
       full_name: Yu Gothic Medium
       post_script_name: YuGothic-Medium
       version: '1.11'
@@ -80,10 +90,12 @@ font_collections:
       post_script_name: YuGothic-Regular
       version: '1.62'
       copyright: Copyright © 2014 JIYUKOBO Ltd. All Rights Reserved.
-  - name: Yu Gothic UI
+  - name: Yu Gothic UI Semilight
     styles:
-    - family_name: Yu Gothic UI
-      type: Semilight
+    - family_name: Yu Gothic UI Semilight
+      type: Regular
+      preferred_family_name: Yu Gothic UI
+      preferred_type: Semilight
       full_name: Yu Gothic UI Semilight
       post_script_name: YuGothicUI-Semilight
       version: '1.10'
@@ -93,29 +105,36 @@ fonts:
   styles:
   - family_name: Yu Mincho
     type: Regular
+    preferred_family_name: Yu Mincho
+    preferred_type: Regular
     full_name: Yu Mincho Regular
     post_script_name: YuMincho-Regular
     version: '1.70'
     copyright: Copyright © 2015 JIYUKOBO Ltd. All Rights Reserved.
     font: YUMIN.TTF
-  - family_name: Yu Mincho
-    type: Demibold
+- name: Yu Mincho Demibold
+  styles:
+  - family_name: Yu Mincho Demibold
+    type: Bold
+    preferred_family_name: Yu Mincho
+    preferred_type: Demibold
     full_name: Yu Mincho Demibold
     post_script_name: YuMincho-Demibold
     version: '1.70'
     copyright: Copyright © 2015 JIYUKOBO Ltd. All Rights Reserved.
     font: YUMINDB.TTF
-  - family_name: Yu Mincho
-    type: Light
+- name: Yu Mincho Light
+  styles:
+  - family_name: Yu Mincho Light
+    type: Regular
+    preferred_family_name: Yu Mincho
+    preferred_type: Light
     full_name: Yu Mincho Light
     post_script_name: YuMincho-Light
     version: '1.61'
     copyright: Copyright © 2015 JIYUKOBO Ltd. All Rights Reserved.
     font: YUMINL.TTF
-extract:
-- format: exe
-- format: msi
-- format: cab
+extract: {}
 copyright: Copyright © 2015 JIYUKOBO Ltd. All Rights Reserved.
 license_url: http://www.jiyu-kobo.co.jp/
 requires_license_agreement: |-
@@ -132,3 +151,4 @@ requires_license_agreement: |-
   If you comply with these license terms, you have the rights below.
 
   1. SUPPORT SERVICES FOR SUPPLEMENT. Microsoft provides support services for this software as described at www.support.microsoft.com/common/international.aspx.
+command: create-formula https://gitlab.com/fontmirror/archive/-/raw/master/eayufontpack.exe

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+
+gem "fontist"

--- a/test/test_formulas.rb
+++ b/test/test_formulas.rb
@@ -1,0 +1,87 @@
+require "json"
+require "yaml"
+require "tmpdir"
+require "fontist"
+
+class TestFormulas
+  def call
+    prepare_formulas do |fonts_by_formula|
+      install(fonts_by_formula)
+    end
+  end
+
+  def install(fonts_by_formula)
+    puts "Formulas changed:"
+    puts fonts_by_formula.keys
+
+    puts "Installing.."
+    fonts_by_formula.each do |formula, font|
+      puts "Formula: '#{formula}', font: '#{font}'."
+      install_font(font)
+    end
+  end
+
+  def install_font(font)
+    Fontist::Font.install(
+      font,
+      force: true,
+      confirmation: "yes",
+      hide_licenses: true,
+      no_progress: true,
+    )
+  end
+
+  def prepare_formulas
+    create_fontist_home do
+      copy_formulas
+      rebuild_index
+
+      yield fonts_by_formula
+    end
+  end
+
+  def create_fontist_home
+    Dir.mktmpdir do |dir|
+      ENV["FONTIST_PATH"] = dir
+
+      yield dir
+
+      ENV["FONTIST_PATH"] = nil
+    end
+  end
+
+  def copy_formulas
+    formulas.each do |formula|
+      path = Fontist.formulas_repo_path.join(formula)
+      dir = File.dirname(path)
+      FileUtils.mkdir_p(dir)
+      FileUtils.cp(formula, dir)
+    end
+  end
+
+  def formulas
+    @formulas ||= JSON.parse(File.read("changed.json")).select do |file|
+      file.start_with?("Formulas/")
+    end
+  end
+
+  def rebuild_index
+    Fontist::Index.rebuild
+  end
+
+  def fonts_by_formula
+    fonts = formulas.map do |file|
+      data = YAML.load_file(file)
+      font_from_formula(data)
+    end
+
+    formulas.zip(fonts).to_h
+  end
+
+  def font_from_formula(data)
+    data.dig("fonts", 0, "name") ||
+      data.dig("font_collections", "fonts", 0, "name")
+  end
+end
+
+TestFormulas.new.call


### PR DESCRIPTION
This PR groups fonts in formulas by default name instead of a preferred one. Also it starts a new branch `v2` which would be used with new fontist only, so previous versions of fontist work with no change.

See fontist/fontist#247