### PR TITLE
#27 Ming font formula

### DIFF
--- a/Formulas/ming_uni.yml
+++ b/Formulas/ming_uni.yml
@@ -1,0 +1,59 @@
+---
+name: Ming Uni
+description: Ming font (ISO 10646 HKSCS-2011)
+resources:
+  Ming_Uni.gz:
+    urls:
+    - https://web.archive.org/web/20181025105830/https://www.ogcio.gov.hk/en/our_work/business/tech_promotion/ccli/terms/doc/ming_uni.ttf.gz
+    sha256: d72ff917fc59046550676cba40d956eb8b6584e1f6e57bf94d3486113a86ff16
+    file_size: 22971372
+fonts:
+- name: Ming(for ISO10646)
+  styles:
+  - family_name: Ming(for ISO10646)
+    type: Regular
+    full_name: Ming(for ISO10646)
+    post_script_name: Ming
+    version: '1.08'
+    copyright: "(c) Copyright DynaComware Corp. 2003"
+    font: ming_uni.ttf
+    source_font: ming_uni.ttf.gz
+min_fontist: "1.16.1"
+extract: {}
+copyright: "(c) Copyright DynaComware Corp. 2003"
+requires_license_agreement: |-
+  Before downloading the Software or Document provided on this Web page, you should read the following terms (Terms of Use). By downloading the Software and Document, you are deemed to agree to these terms.
+
+  1. The Government of the Hong Kong Special Administrative Region (HKSARG) has the right to amend or vary the terms under this Terms of Use from time to time at its sole discretion.
+
+  2. By using the Software and Document, you irrevocably agree that the HKSARG may from time to time vary this Terms of Use without further notice to you and you also irrevocably agree to be bound by the most updated version of the Terms of Use.
+
+  3. You have the sole responsibility of obtaining the most updated version of the Terms of Use which is available in the OGCIO website (https://www.ogcio.gov.hk/en/our_work/business/tech_promotion/ccli/terms/terms.html).
+
+  4. By accepting this Terms of Use, HKSARG shall grant you a non-exclusive license to use the Software and Document for any purpose, subject to clause 5 below.
+
+  5. You are not allowed to make copies of the Software and Document except it is incidental to and necessary for the normal use of the Software. You are not allowed to adapt or modify the Software and Document or to distribute, sell, rent, or make available to the public the Software and Document, including copies or an adaptation of them.
+
+  6. The Software and Document are protected by copyright. The licensors of the Government of Hong Kong Special Administrative Region are the owners of all copyright works in the Software and Document. All rights reserved.
+
+  7. You understand and agree that use of the Software and Document are at your sole risk, that any material and/or data downloaded or otherwise obtained in relation to the Software and Document is at your discretion and risk and that you will be solely responsible for any damage caused to your computer system or loss of data or any other loss that results from the download and use of the Software and Document in any manner whatsoever.
+
+  8. In relation to the Software and Document, HKSARG hereby disclaims all warranties and conditions, including all implied warranties and conditions of merchantability, fitness for a particular purpose and non-infringement.
+
+  9. HKSARG will not be liable for any direct, indirect, incidental, special or consequential loss of any kind resulting from the use of or the inability to use the Software and Document even if HKSARG has been advised of the possibility of such loss.
+
+  10. You agree not to sue HKSARG and agree to indemnify, defend and hold harmless HKSARG, its officers and employees from any and all third party claims, liability, damages and/or costs (including, but not limited to, legal fees) arising from your use of the Software and Document, your violation of the Terms of Use or infringement of any intellectual property or other right of any person or entity.
+
+  11. The Terms of Use will be governed by and construed in accordance with the laws of Hong Kong.
+
+  12. Any waiver of any provision of the Terms of Use will be effective only if in writing and signed by HKSARG or its representative.
+
+  13. If for any reason a court of competent jurisdiction finds any provision or portion of the Terms of Use to be unenforceable, the remainder of the Terms of Use will continue in full force and effect.
+
+  14. The Terms of Use constitute the entire agreement between the parties with respect to the subject matter hereof and supersedes and replaces all prior or contemporaneous understandings or agreements, written or oral, regarding such subject matter.
+
+  15.In addition to the licence granted in Clause 4, HKSARG hereby grants you a non-exclusive limited licence to reproduce and distribute the Software and Document with the following conditions:
+  (i)   not for financial gain unless it is incidental;
+  (ii)  reproduction and distribution of the Software and Document in complete and unmodified form; and
+  (iii) when you distribute the Software and Document, you agree to attach the Terms of Use and a statement that the latest version of the Terms of Use is available from the "Office of the Government Chief Information Officer" Web site (http://www.ogcio.gov.hk/en/our_work/business/tech_promotion/ccli/terms/terms.html).
+command: create-formula --name Ming\ Uni https://web.archive.org/web/20181025105830/https://www.ogcio.gov.hk/en/our_work/business/tech_promotion/ccli/terms/doc/ming_uni.ttf.gz


### PR DESCRIPTION
- #27

Note:

Some work on `fontist` side need because for some reason ttf font file was uploaded with `.gz` suffix but it actually not an archive

Proposed solution:

`fontist` should handle

```
...
extract:
  options: ttf
...
```

And ignore filename extension