### PR TITLE
Restore the Office preview formula

### DIFF
--- a/Formulas/office_preview.yml
+++ b/Formulas/office_preview.yml
@@ -1,0 +1,3199 @@
+---
+description: Office Preview
+homepage: http://www.monotype.com/html/mtname/ms_welcome.html
+resources:
+  Office_Preview.pkg:
+    urls:
+    - http://download.microsoft.com/download/8/1/3/8136bf31-4c2e-4b5f-bee9-117ab004ab35/microsoft_excel_15.11.1_updater.pkg
+    sha256: 34024135a047ca0ef3b1ab499ab7a5584b313b9eb8954c1dd38712dc6c8a04ec
+    file_size: 736800648
+font_collections:
+- filename: Cambria.ttc
+  fonts:
+  - name: Cambria
+    styles:
+    - family_name: Cambria
+      type: Regular
+      full_name: Cambria
+      post_script_name: Cambria
+      version: 6.90i
+      description: 'Cambria has been designed for on-screen reading and to look good
+        when printed at small sizes. It has very even spacing and proportions. Diagonal
+        and vertical hairlines and serifs are relatively strong, while horizontal
+        serifs are small and intend to emphasize stroke endings rather than stand
+        out themselves. This principle is most noticeable in the italics where the
+        lowercase characters are subdued in style to be at their best as elements
+        of word-images. When Cambria is used for captions at sizes over 20 point,
+        the  inter-character spacing should be slightly reduced for best results.
+        The design isn''t just intended for business documents: The regular weight
+        has been extended with a large set of math and science symbols. The Greek
+        and Cyrillic has been designed under close supervision of an international
+        team of experts, who aimed to set a historical new standard in multi-script
+        type design.'
+      copyright: "© 2015 Microsoft Corporation. All Rights Reserved."
+  - name: Cambria Math
+    styles:
+    - family_name: Cambria Math
+      type: Regular
+      full_name: Cambria Math
+      post_script_name: CambriaMath
+      version: 6.90i
+      description: 'Cambria has been designed for on-screen reading and to look good
+        when printed at small sizes. It has very even spacing and proportions. Diagonal
+        and vertical hairlines and serifs are relatively strong, while horizontal
+        serifs are small and intend to emphasize stroke endings rather than stand
+        out themselves. This principle is most noticeable in the italics where the
+        lowercase characters are subdued in style to be at their best as elements
+        of word-images. When Cambria is used for captions at sizes over 20 point,
+        the  inter-character spacing should be slightly reduced for best results.
+        The design isn''t just intended for business documents: The regular weight
+        has been extended with a large set of math and science symbols. The Greek
+        and Cyrillic has been designed under close supervision of an international
+        team of experts, who aimed to set a historical new standard in multi-script
+        type design.'
+      copyright: "© 2015 Microsoft Corporation. All Rights Reserved."
+- filename: HGRGE.ttc
+  fonts:
+  - name: HGGothicE
+    styles:
+    - family_name: HGGothicE
+      type: Regular
+      full_name: HGGothicE
+      post_script_name: HGGothicE
+      version: '5.02'
+      copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+  - name: HGPGothicE
+    styles:
+    - family_name: HGPGothicE
+      type: Regular
+      full_name: HGPGothicE
+      post_script_name: HGPGothicE
+      version: '5.02'
+      copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+  - name: HGSGothicE
+    styles:
+    - family_name: HGSGothicE
+      type: Regular
+      full_name: HGSGothicE
+      post_script_name: HGSGothicE
+      version: '5.02'
+      copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+- filename: HGRME.ttc
+  fonts:
+  - name: HGMinchoE
+    styles:
+    - family_name: HGMinchoE
+      type: Regular
+      full_name: HGMinchoE
+      post_script_name: HGMinchoE
+      version: '5.02'
+      copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+  - name: HGPMinchoE
+    styles:
+    - family_name: HGPMinchoE
+      type: Regular
+      full_name: HGPMinchoE
+      post_script_name: HGPMinchoE
+      version: '5.02'
+      copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+  - name: HGSMinchoE
+    styles:
+    - family_name: HGSMinchoE
+      type: Regular
+      full_name: HGSMinchoE
+      post_script_name: HGSMinchoE
+      version: '5.02'
+      copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+- filename: HGRSGU.ttc
+  fonts:
+  - name: HGPSoeiKakugothicUB
+    styles:
+    - family_name: HGPSoeiKakugothicUB
+      type: Regular
+      full_name: HGPSoeiKakugothicUB
+      post_script_name: HGPSoeiKakugothicUB
+      version: '5.01'
+      copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:Soeikikaku Co.,ltd."
+  - name: HGSSoeiKakugothicUB
+    styles:
+    - family_name: HGSSoeiKakugothicUB
+      type: Regular
+      full_name: HGSSoeiKakugothicUB
+      post_script_name: HGSSoeiKakugothicUB
+      version: '5.01'
+      copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:Soeikikaku Co.,ltd."
+  - name: HGSoeiKakugothicUB
+    styles:
+    - family_name: HGSoeiKakugothicUB
+      type: Regular
+      full_name: HGSoeiKakugothicUB
+      post_script_name: HGSoeiKakugothicUB
+      version: '5.01'
+      copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:Soeikikaku Co.,ltd."
+- filename: batang.ttc
+  fonts:
+  - name: Batang
+    styles:
+    - family_name: Batang
+      type: Regular
+      full_name: Batang
+      post_script_name: Batang
+      version: '5.00'
+      copyright: "(c) Copyright HanYang I&C Co.,LTD. 2000"
+  - name: BatangChe
+    styles:
+    - family_name: BatangChe
+      type: Regular
+      full_name: BatangChe
+      post_script_name: BatangChe
+      version: '5.00'
+      copyright: "(c) Copyright HanYang I&C Co.,LTD. 2000"
+  - name: Gungsuh
+    styles:
+    - family_name: Gungsuh
+      type: Regular
+      full_name: Gungsuh
+      post_script_name: Gungsuh
+      version: '5.00'
+      copyright: "(c) Copyright HanYang I&C Co.,LTD. 2000"
+  - name: GungsuhChe
+    styles:
+    - family_name: GungsuhChe
+      type: Regular
+      full_name: GungsuhChe
+      post_script_name: GungsuhChe
+      version: '5.00'
+      copyright: "(c) Copyright HanYang I&C Co.,LTD. 2000"
+- filename: gulim.ttc
+  fonts:
+  - name: Dotum
+    styles:
+    - family_name: Dotum
+      type: Regular
+      full_name: Dotum
+      post_script_name: Dotum
+      version: '5.00'
+      copyright: "(c) Copyright HanYang I&C Co.,LTD. 2000"
+  - name: DotumChe
+    styles:
+    - family_name: DotumChe
+      type: Regular
+      full_name: DotumChe
+      post_script_name: DotumChe
+      version: '5.00'
+      copyright: "(c) Copyright HanYang I&C Co.,LTD. 2000"
+  - name: Gulim
+    styles:
+    - family_name: Gulim
+      type: Regular
+      full_name: Gulim
+      post_script_name: Gulim
+      version: '5.01'
+      copyright: "© 2009 HanYang I&C Co., LTD."
+  - name: GulimChe
+    styles:
+    - family_name: GulimChe
+      type: Regular
+      full_name: GulimChe
+      post_script_name: GulimChe
+      version: '5.00'
+      copyright: "(c) Copyright HanYang I&C Co.,LTD. 2000"
+- filename: mingliu.ttc
+  fonts:
+  - name: MingLiU
+    styles:
+    - family_name: MingLiU
+      type: Regular
+      full_name: MingLiU
+      post_script_name: MingLiU
+      version: 7.01i
+      copyright: "(c) Copyright DynaComware Corp. 2008"
+  - name: MingLiU_HKSCS
+    styles:
+    - family_name: MingLiU_HKSCS
+      type: Regular
+      full_name: MingLiU_HKSCS
+      post_script_name: Ming-Lt-HKSCS-UNI-H
+      version: 7.01i
+      copyright: "(c) Copyright DynaComware Corp. 2008"
+  - name: PMingLiU
+    styles:
+    - family_name: PMingLiU
+      type: Regular
+      full_name: PMingLiU
+      post_script_name: PMingLiU
+      version: 7.05i
+      copyright: "(c) Copyright DynaComware Corp. 2008"
+- filename: mingliub.ttc
+  fonts:
+  - name: MingLiU-ExtB
+    styles:
+    - family_name: MingLiU-ExtB
+      type: Regular
+      full_name: MingLiU-ExtB
+      post_script_name: MingLiU-ExtB
+      version: 7.01i
+      copyright: "© DynaComware Corp. 2008"
+  - name: MingLiU_HKSCS-ExtB
+    styles:
+    - family_name: MingLiU_HKSCS-ExtB
+      type: Regular
+      full_name: MingLiU_HKSCS-ExtB
+      post_script_name: MingLiU-HKSCS-ExtB
+      version: 7.01i
+      copyright: "© DynaComware Corp. 2008"
+  - name: PMingLiU-ExtB
+    styles:
+    - family_name: PMingLiU-ExtB
+      type: Regular
+      full_name: PMingLiU-ExtB
+      post_script_name: PMingLiU-ExtB
+      version: 7.01i
+      copyright: "© DynaComware Corp. 2008"
+- filename: msgothic.ttc
+  fonts:
+  - name: MS Gothic
+    styles:
+    - family_name: MS Gothic
+      type: Regular
+      full_name: MS Gothic
+      post_script_name: MS-Gothic
+      version: 5.10i
+      description: The default glyph shapes of this font are based on JIS2004. This
+        font also provides access to a set of JIS90 legacy glyphs via 'jp90' OpenType
+        layout table.
+      copyright: "© 2012 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+  - name: MS PGothic
+    styles:
+    - family_name: MS PGothic
+      type: Regular
+      full_name: MS PGothic
+      post_script_name: MS-PGothic
+      version: 5.10i
+      description: The default glyph shapes of this font are based on JIS2004. This
+        font also provides access to a set of JIS90 legacy glyphs via 'jp90' OpenType
+        layout table.
+      copyright: "© 2012 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+  - name: MS UI Gothic
+    styles:
+    - family_name: MS UI Gothic
+      type: Regular
+      full_name: MS UI Gothic
+      post_script_name: MS-UIGothic
+      version: 5.10i
+      copyright: "© 2012 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+- filename: msmincho.ttc
+  fonts:
+  - name: MS Mincho
+    styles:
+    - family_name: MS Mincho
+      type: Regular
+      full_name: MS Mincho
+      post_script_name: MS-Mincho
+      version: 5.10i
+      description: The default glyph shapes of this font are based on JIS2004. This
+        font also provides access to a set of JIS90 legacy glyphs via 'jp90' OpenType
+        layout table.
+      copyright: "© 2012 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+  - name: MS PMincho
+    styles:
+    - family_name: MS PMincho
+      type: Regular
+      full_name: MS PMincho
+      post_script_name: MS-PMincho
+      version: 5.10i
+      description: The default glyph shapes of this font are based on JIS2004. This
+        font also provides access to a set of JIS90 legacy glyphs via 'jp90' OpenType
+        layout table.
+      copyright: "© 2012 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+fonts:
+- name: Abadi MT Condensed Extra Bold
+  styles:
+  - family_name: Abadi MT Condensed Extra Bold
+    type: Regular
+    full_name: Abadi MT Condensed Extra Bold
+    post_script_name: AbadiMT-CondensedExtraBold
+    version: '1.51'
+    copyright: Typeface data Copyright © 1992-94 The Monotype Corporation. Copyright
+      1994 Microsoft Corporation. All rights reserved.
+    font: AbadiMTCondensedExtraBold.ttf
+- name: Abadi MT Condensed Light
+  styles:
+  - family_name: Abadi MT Condensed Light
+    type: Regular
+    full_name: Abadi MT Condensed Light
+    post_script_name: AbadiMT-CondensedLight
+    version: '1.51'
+    copyright: Typeface data Copyright © 1992-94 The Monotype Corporation. Copyright
+      1994 Microsoft Corporation. All rights reserved.
+    font: AbadiMTCondensedLight.ttf
+- name: Arial
+  styles:
+  - family_name: Arial
+    type: Bold
+    full_name: Arial Bold
+    post_script_name: Arial-BoldMT
+    version: 6.80i
+    copyright: "© 2012 The Monotype Corporation. All Rights Reserved."
+    font: arialbd.ttf
+  - family_name: Arial
+    type: Bold Italic
+    full_name: Arial Bold Italic
+    post_script_name: Arial-BoldItalicMT
+    version: 6.80i
+    copyright: "© 2012 The Monotype Corporation. All Rights Reserved."
+    font: arialbi.ttf
+  - family_name: Arial
+    type: Italic
+    full_name: Arial Italic
+    post_script_name: Arial-ItalicMT
+    version: 6.80i
+    copyright: "© 2012 The Monotype Corporation. All Rights Reserved."
+    font: ariali.ttf
+  - family_name: Arial
+    type: Regular
+    full_name: Arial
+    post_script_name: ArialMT
+    version: 6.80i
+    copyright: "© 2012 The Monotype Corporation. All Rights Reserved."
+    font: arial.ttf
+- name: Arial Black
+  styles:
+  - family_name: Arial Black
+    type: Regular
+    preferred_family_name: Arial
+    preferred_type: Black
+    full_name: Arial Black
+    post_script_name: Arial-Black
+    version: 5.21i
+    description: Monotype Drawing Office 1982. A contemporary sans serif design, Arial
+      contains more humanist characteristics than many of its predecessors and as
+      such is more in tune with the mood of the last decades of the twentieth century.
+      The overall treatment of curves is softer and fuller than in most industrial-style
+      sans serif faces. Terminal strokes are cut on the diagonal which helps to give
+      the face a less mechanical appearance. Arial is an extremely versatile family
+      of typefaces which can be used with equal success for text setting in reports,
+      presentations, magazines etc, and for display use in newspapers, advertising
+      and promotions.
+    copyright: "© 2012 The Monotype Corporation. All Rights Reserved. Arial is a trademark
+      of The Monotype Corporation."
+    font: ariblk.ttf
+- name: Arial Narrow
+  styles:
+  - family_name: Arial Narrow
+    type: Bold Italic
+    full_name: Arial Narrow Bold Italic
+    post_script_name: ArialNarrow-BoldItalic
+    version: '2.35'
+    description: Monotype Drawing Office 1982. A contemporary sans serif design, Arial
+      contains more humanist characteristics than many of its predecessors and as
+      such is more in tune with the mood of the last decades of the twentieth century.
+      The overall treatment of curves is softer and fuller than in most industrial-style
+      sans serif faces. Terminal strokes are cut on the diagonal which helps to give
+      the face a less mechanical appearance. Arial is an extremely versatile family
+      of typefaces which can be used with equal success for text setting in reports,
+      presentations, magazines etc, and for display use in newspapers, advertising
+      and promotions.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 1990-91 All Rights Reserved.
+    font: ArialNarrowBoldItalic.ttf
+  - family_name: Arial Narrow
+    type: Italic
+    full_name: Arial Narrow Italic
+    post_script_name: ArialNarrow-Italic
+    version: '2.35'
+    description: Monotype Drawing Office 1982. A contemporary sans serif design, Arial
+      contains more humanist characteristics than many of its predecessors and as
+      such is more in tune with the mood of the last decades of the twentieth century.
+      The overall treatment of curves is softer and fuller than in most industrial-style
+      sans serif faces. Terminal strokes are cut on the diagonal which helps to give
+      the face a less mechanical appearance. Arial is an extremely versatile family
+      of typefaces which can be used with equal success for text setting in reports,
+      presentations, magazines etc, and for display use in newspapers, advertising
+      and promotions.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 19-1991 All Rights Reserved.
+    font: ArialNarrowItalic.ttf
+- name: Arial Rounded MT Bold
+  styles:
+  - family_name: Arial Rounded MT Bold
+    type: Regular
+    full_name: Arial Rounded MT Bold
+    post_script_name: ArialRoundedMTBold
+    version: '1.51'
+    copyright: Copyright © 1993 , Monotype Typography ltd.
+    font: ArialRoundedMTBold.ttf
+- name: Baskerville Old Face
+  styles:
+  - family_name: Baskerville Old Face
+    type: Regular
+    full_name: Baskerville Old Face
+    post_script_name: BaskOldFace
+    version: '1.51'
+    copyright: Typeface © 1992 Stephenson Blake (Holdings) Ltd. Data © 1992 URW. Portions
+      © 1992 Microsoft Corp. All rights reserved.
+    font: BaskervilleOldFace.ttf
+- name: Bauhaus 93
+  styles:
+  - family_name: Bauhaus 93
+    type: Regular
+    full_name: Bauhaus 93
+    post_script_name: Bauhaus93
+    version: '1.52'
+    copyright: URW Software, Copyright 1993 by URW
+    font: Bauhaus93.ttf
+- name: Bell MT
+  styles:
+  - family_name: Bell MT
+    type: Bold
+    full_name: Bell MT Bold
+    post_script_name: BellMTBold
+    version: '1.51'
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc, Type Solutions inc 1990-1992. All rights reserved. Portions © 1992 Microsoft
+      Corp.
+    font: BellMTBold.ttf
+  - family_name: Bell MT
+    type: Italic
+    full_name: Bell MT Italic
+    post_script_name: BellMTItalic
+    version: '1.51'
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc, Type Solutions Inc 1990-1992. All rights reserved. Portions © 1992 Microsoft
+      Corp.
+    font: BellMTItalic.ttf
+  - family_name: Bell MT
+    type: Regular
+    full_name: Bell MT
+    post_script_name: BellMT
+    version: '1.51'
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc, Type Solutions Inc 1990-1992. All rights reserved.
+    font: BellMT.ttf
+- name: Bernard MT Condensed
+  styles:
+  - family_name: Bernard MT Condensed
+    type: Regular
+    full_name: Bernard MT Condensed
+    post_script_name: BernardMT-Condensed
+    version: '1.51'
+    copyright: Design and data by The Monotype Corporation. © 1993. Microsoft Corporation.
+      All rights reserved.
+    font: BernardMTCondensed.ttf
+- name: Book Antiqua
+  styles:
+  - family_name: Book Antiqua
+    type: Bold
+    full_name: Book Antiqua Bold
+    post_script_name: BookAntiqua-Bold
+    version: '2.35'
+    description: This is a roman typeface based on pen-drawn letters of the Italian
+      Renaissance. Because it is distinctive and gentle in appearance it can be used
+      to give a document a different feel than is given by the more geometrical designs
+      of most text faces. It is also useful for occasional lines, as in letter headings
+      and compliments slips. Its beautiful italic has many uses of its own.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Book Antiqua™ is a trademark of The Monotype Corporation which may
+      be registered in certain jurisdictions.
+    font: Book Antiqua Bold.ttf
+  - family_name: Book Antiqua
+    type: Bold Italic
+    full_name: Book Antiqua Bold Italic
+    post_script_name: BookAntiqua-BoldItalic
+    version: '2.35'
+    description: This is a roman typeface based on pen-drawn letters of the Italian
+      Renaissance. Because it is distinctive and gentle in appearance it can be used
+      to give a document a different feel than is given by the more geometrical designs
+      of most text faces. It is also useful for occasional lines, as in letter headings
+      and compliments slips. Its beautiful italic has many uses of its own.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Book Antiqua™ is a trademark of The Monotype Corporation which may
+      be registered in certain jurisdictions.
+    font: Book Antiqua Bold Italic.ttf
+  - family_name: Book Antiqua
+    type: Italic
+    full_name: Book Antiqua Italic
+    post_script_name: BookAntiqua-Italic
+    version: '2.35'
+    description: This is a roman typeface based on pen-drawn letters of the Italian
+      Renaissance. Because it is distinctive and gentle in appearance it can be used
+      to give a document a different feel than is given by the more geometrical designs
+      of most text faces. It is also useful for occasional lines, as in letter headings
+      and compliments slips. Its beautiful italic has many uses of its own.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Book Antiqua™ is a trademark of The Monotype Corporation which may
+      be registered in certain jurisdictions.
+    font: Book Antiqua Italic.ttf
+  - family_name: Book Antiqua
+    type: Regular
+    full_name: Book Antiqua
+    post_script_name: BookAntiqua
+    version: '2.35'
+    description: This is a roman typeface based on pen-drawn letters of the Italian
+      Renaissance. Because it is distinctive and gentle in appearance it can be used
+      to give a document a different feel than is given by the more geometrical designs
+      of most text faces. It is also useful for occasional lines, as in letter headings
+      and compliments slips. Its beautiful italic has many uses of its own.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Book Antiqua™ is a trademark of The Monotype Corporation which may
+      be registered in certain jurisdictions.
+    font: Book Antiqua.ttf
+- name: Bookman Old Style
+  styles:
+  - family_name: Bookman Old Style
+    type: Bold
+    full_name: Bookman Old Style Bold
+    post_script_name: BookmanOldStyle-Bold
+    version: '2.35'
+    description: The origins of Bookman Old Style lie in the typeface called Oldstyle
+      Antique, designed by A C Phemister circa 1858 for the Miller and Richard foundry
+      in Edinburgh, Scotland. Many American foundries made versions of this type which
+      eventually became known as Bookman. Monotype Bookman Old Style roman is based
+      on earlier Lanston Monotype and ATF models. The italic has been re drawn following
+      the style of the Oldstyle Antique italics of Miller and Richard. Although called
+      'Old Style', the near vertical stress of the face puts it into the transitional
+      category. A legible and robust text face.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Bookman Old Style™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Bookman Old Style Bold.ttf
+  - family_name: Bookman Old Style
+    type: Bold Italic
+    full_name: Bookman Old Style Bold Italic
+    post_script_name: BookmanOldStyle-BoldItalic
+    version: '2.35'
+    description: The origins of Bookman Old Style lie in the typeface called Oldstyle
+      Antique, designed by A C Phemister circa 1858 for the Miller and Richard foundry
+      in Edinburgh, Scotland. Many American foundries made versions of this type which
+      eventually became known as Bookman. Monotype Bookman Old Style roman is based
+      on earlier Lanston Monotype and ATF models. The italic has been re drawn following
+      the style of the Oldstyle Antique italics of Miller and Richard. Although called
+      'Old Style', the near vertical stress of the face puts it into the transitional
+      category. A legible and robust text face.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Bookman Old Style™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Bookman Old Style Bold Italic.ttf
+  - family_name: Bookman Old Style
+    type: Italic
+    full_name: Bookman Old Style Italic
+    post_script_name: BookmanOldStyle-Italic
+    version: '2.36'
+    description: The origins of Bookman Old Style lie in the typeface called Oldstyle
+      Antique, designed by A C Phemister circa 1858 for the Miller and Richard foundry
+      in Edinburgh, Scotland. Many American foundries made versions of this type which
+      eventually became known as Bookman. Monotype Bookman Old Style roman is based
+      on earlier Lanston Monotype and ATF models. The italic has been re drawn following
+      the style of the Oldstyle Antique italics of Miller and Richard. Although called
+      'Old Style', the near vertical stress of the face puts it into the transitional
+      category. A legible and robust text face.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Bookman Old Style™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Bookman Old Style Italic.ttf
+  - family_name: Bookman Old Style
+    type: Regular
+    full_name: Bookman Old Style
+    post_script_name: BookmanOldStyle
+    version: '2.35'
+    description: The origins of Bookman Old Style lie in the typeface called Oldstyle
+      Antique, designed by A C Phemister circa 1858 for the Miller and Richard foundry
+      in Edinburgh, Scotland. Many American foundries made versions of this type which
+      eventually became known as Bookman. Monotype Bookman Old Style roman is based
+      on earlier Lanston Monotype and ATF models. The italic has been re drawn following
+      the style of the Oldstyle Antique italics of Miller and Richard. Although called
+      'Old Style', the near vertical stress of the face puts it into the transitional
+      category. A legible and robust text face.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Bookman Old Style™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Bookman Old Style.ttf
+- name: Bookshelf Symbol 7
+  styles:
+  - family_name: Bookshelf Symbol 7
+    type: Regular
+    full_name: Bookshelf Symbol 7
+    post_script_name: BookshelfSymbolSeven
+    version: '1.03'
+    copyright: "(C)2003 data:RICOH Co.,Ltd. typeface:RICOH Co.,Ltd."
+    font: Bookshelf Symbol 7.ttf
+- name: Braggadocio
+  styles:
+  - family_name: Braggadocio
+    type: Regular
+    full_name: Braggadocio
+    post_script_name: Braggadocio
+    version: '1.52'
+    copyright: Copyright (c) 1992 Monotype Corporation plc. All rights reserved. Portions
+      © 1992 Microsoft Corp.
+    font: Braggadocio.ttf
+- name: Britannic Bold
+  styles:
+  - family_name: Britannic Bold
+    type: Regular
+    full_name: Britannic Bold
+    post_script_name: BritannicBold
+    version: '1.51'
+    copyright: Typeface © 1992 Stephenson Blake (Holdings) Ltd. Data © 1992 URW. Portions
+      © 1992 Microsoft Corp. All rights reserved.
+    font: BritannicBold.ttf
+- name: Calibri
+  styles:
+  - family_name: Calibri
+    type: Bold
+    full_name: Calibri Bold
+    post_script_name: Calibri-Bold
+    version: 6.01i
+    description: Calibri is a modern sans serif family with subtle roundings on stems
+      and corners. It features real italics, small caps, and multiple numeral sets.
+      Its proportions allow high impact in tightly set lines of big and small text
+      alike. Calibri's many curves and the new rasteriser team up in bigger sizes
+      to reveal a warm and soft character.
+    copyright: "© 2015 Microsoft Corporation. All Rights Reserved. Designed by Luc(as)
+      de Groot"
+    font: Calibrib.ttf
+  - family_name: Calibri
+    type: Bold Italic
+    full_name: Calibri Bold Italic
+    post_script_name: Calibri-BoldItalic
+    version: 6.01i
+    description: Calibri is a modern sans serif family with subtle roundings on stems
+      and corners. It features real italics, small caps, and multiple numeral sets.
+      Its proportions allow high impact in tightly set lines of big and small text
+      alike. Calibri's many curves and the new rasteriser team up in bigger sizes
+      to reveal a warm and soft character.
+    copyright: "© 2015 Microsoft Corporation. All Rights Reserved. Designed by Luc(as)
+      de Groot"
+    font: Calibriz.ttf
+  - family_name: Calibri
+    type: Italic
+    full_name: Calibri Italic
+    post_script_name: Calibri-Italic
+    version: 6.01i
+    description: Calibri is a modern sans serif family with subtle roundings on stems
+      and corners. It features real italics, small caps, and multiple numeral sets.
+      Its proportions allow high impact in tightly set lines of big and small text
+      alike. Calibri's many curves and the new rasteriser team up in bigger sizes
+      to reveal a warm and soft character.
+    copyright: "© 2014 Microsoft Corporation. All Rights Reserved."
+    font: Calibrii.ttf
+  - family_name: Calibri
+    type: Regular
+    full_name: Calibri
+    post_script_name: Calibri
+    version: 6.01i
+    description: Calibri is a modern sans serif family with subtle roundings on stems
+      and corners. It features real italics, small caps, and multiple numeral sets.
+      Its proportions allow high impact in tightly set lines of big and small text
+      alike. Calibri's many curves and the new rasteriser team up in bigger sizes
+      to reveal a warm and soft character.
+    copyright: "© 2015 Microsoft Corporation. All Rights Reserved."
+    font: Calibri.ttf
+- name: Calibri Light
+  styles:
+  - family_name: Calibri Light
+    type: Italic
+    preferred_family_name: Calibri
+    preferred_type: Light Italic
+    full_name: Calibri Light Italic
+    post_script_name: Calibri-LightItalic
+    version: 2.21i
+    description: Calibri is a modern sans serif family with subtle roundings on stems
+      and corners. It features real italics, small caps, and multiple numeral sets.
+      Its proportions allow high impact in tightly set lines of big and small text
+      alike. Calibri's many curves and the new rasteriser team up in bigger sizes
+      to reveal a warm and soft character.
+    copyright: "© 2015 Microsoft Corporation. All Rights Reserved. Designed by Luc(as)
+      de Groot"
+    font: calibrili.ttf
+  - family_name: Calibri Light
+    type: Regular
+    preferred_family_name: Calibri
+    preferred_type: Light
+    full_name: Calibri Light
+    post_script_name: Calibri-Light
+    version: 2.21i
+    description: Calibri is a modern sans serif family with subtle roundings on stems
+      and corners. It features real italics, small caps, and multiple numeral sets.
+      Its proportions allow high impact in tightly set lines of big and small text
+      alike. Calibri's many curves and the new rasteriser team up in bigger sizes
+      to reveal a warm and soft character.
+    copyright: "© 2015 Microsoft Corporation. All Rights Reserved. Designed by Luc(as)
+      de Groot"
+    font: calibril.ttf
+- name: Calisto MT
+  styles:
+  - family_name: Calisto MT
+    type: Bold
+    full_name: Calisto MT Bold
+    post_script_name: CalisMTBol
+    version: '1.62'
+    description: A typeface whose appeal as a text face lies in its very even colour
+      on the page, while its robust construction means that it can wrk equally well
+      at display sizes. The slightly calligraphic treatment of letter shapes and the
+      classical proportions of the face give a clean elegance on the page. Calisto
+      is a graceful and interesting addition to the typographer's repertoire and will
+      prove particularly useful for book, magazine and advertizing work.
+    copyright: Digitized data copyright (C) 1992-1997 The Monotype Corporation. All
+      rights reserved. Calisto® is a trademark of The Monotype Corporation which may
+      be registered in certain jurisdictions.
+    font: Calisto MT Bold.ttf
+  - family_name: Calisto MT
+    type: Bold Italic
+    full_name: Calisto MT Bold Italic
+    post_script_name: CalistoMT-BoldItalic
+    version: '1.62'
+    description: A typeface whose appeal as a text face lies in its very even colour
+      on the page, while its robust construction means that it can wrk equally well
+      at display sizes. The slightly calligraphic treatment of letter shapes and the
+      classical proportions of the face give a clean elegance on the page. Calisto
+      is a graceful and interesting addition to the typographer's repertoire and will
+      prove particularly useful for book, magazine and advertizing work.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1997. All rights
+      reserved. Calisto® is a trademark of The Monotype Corporation which may be registered
+      in certain jurisdictions.
+    font: CalistoMTBoldItalic.ttf
+  - family_name: Calisto MT
+    type: Italic
+    full_name: Calisto MT Italic
+    post_script_name: CalistoMT-Italic
+    version: '1.62'
+    description: A typeface whose appeal as a text face lies in its very even colour
+      on the page, while its robust construction means that it can wrk equally well
+      at display sizes. The slightly calligraphic treatment of letter shapes and the
+      classical proportions of the face give a clean elegance on the page. Calisto
+      is a graceful and interesting addition to the typographer's repertoire and will
+      prove particularly useful for book, magazine and advertizing work.
+    copyright: Digitized data copyright (C) 1992 - 1997 The Monotype Corporation.
+      All rights reserved. Calisto® is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Calisto MT Italic.ttf
+  - family_name: Calisto MT
+    type: Regular
+    full_name: Calisto MT
+    post_script_name: CalistoMT
+    version: '1.62'
+    description: A typeface whose appeal as a text face lies in its very even colour
+      on the page, while its robust construction means that it can wrk equally well
+      at display sizes. The slightly calligraphic treatment of letter shapes and the
+      classical proportions of the face give a clean elegance on the page. Calisto
+      is a graceful and interesting addition to the typographer's repertoire and will
+      prove particularly useful for book, magazine and advertizing work.
+    copyright: Digitized data copyright (C) 1991-1997 The Monotype Corporation. All
+      rights reserved. Calisto® is a trademark of The Monotype Corporation which may
+      be registered in certain jurisdictions.
+    font: Calisto MT.ttf
+- name: Cambria
+  styles:
+  - family_name: Cambria
+    type: Bold
+    full_name: Cambria Bold
+    post_script_name: Cambria-Bold
+    version: 6.90i
+    description: 'Cambria has been designed for on-screen reading and to look good
+      when printed at small sizes. It has very even spacing and proportions. Diagonal
+      and vertical hairlines and serifs are relatively strong, while horizontal serifs
+      are small and intend to emphasize stroke endings rather than stand out themselves.
+      This principle is most noticeable in the italics where the lowercase characters
+      are subdued in style to be at their best as elements of word-images. When Cambria
+      is used for captions at sizes over 20 point, the  inter-character spacing should
+      be slightly reduced for best results. The design isn''t just intended for business
+      documents: The regular weight has been extended with a large set of math and
+      science symbols. The Greek and Cyrillic has been designed under close supervision
+      of an international team of experts, who aimed to set a historical new standard
+      in multi-script type design.'
+    copyright: "© 2015 Microsoft Corporation. All Rights Reserved."
+    font: Cambriab.TTF
+  - family_name: Cambria
+    type: Bold Italic
+    full_name: Cambria Bold Italic
+    post_script_name: Cambria-BoldItalic
+    version: 6.90i
+    description: 'Cambria has been designed for on-screen reading and to look good
+      when printed at small sizes. It has very even spacing and proportions. Diagonal
+      and vertical hairlines and serifs are relatively strong, while horizontal serifs
+      are small and intend to emphasize stroke endings rather than stand out themselves.
+      This principle is most noticeable in the italics where the lowercase characters
+      are subdued in style to be at their best as elements of word-images. When Cambria
+      is used for captions at sizes over 20 point, the  inter-character spacing should
+      be slightly reduced for best results. The design isn''t just intended for business
+      documents: The regular weight has been extended with a large set of math and
+      science symbols. The Greek and Cyrillic has been designed under close supervision
+      of an international team of experts, who aimed to set a historical new standard
+      in multi-script type design.'
+    copyright: "© 2015 Microsoft Corporation. All Rights Reserved."
+    font: Cambriaz.TTF
+  - family_name: Cambria
+    type: Italic
+    full_name: Cambria Italic
+    post_script_name: Cambria-Italic
+    version: 6.90i
+    description: 'Cambria has been designed for on-screen reading and to look good
+      when printed at small sizes. It has very even spacing and proportions. Diagonal
+      and vertical hairlines and serifs are relatively strong, while horizontal serifs
+      are small and intend to emphasize stroke endings rather than stand out themselves.
+      This principle is most noticeable in the italics where the lowercase characters
+      are subdued in style to be at their best as elements of word-images. When Cambria
+      is used for captions at sizes over 20 point, the  inter-character spacing should
+      be slightly reduced for best results. The design isn''t just intended for business
+      documents: The regular weight has been extended with a large set of math and
+      science symbols. The Greek and Cyrillic has been designed under close supervision
+      of an international team of experts, who aimed to set a historical new standard
+      in multi-script type design.'
+    copyright: "© 2015 Microsoft Corporation. All Rights Reserved."
+    font: Cambriai.TTF
+- name: Candara
+  styles:
+  - family_name: Candara
+    type: Bold
+    full_name: Candara Bold
+    post_script_name: Candara-Bold
+    version: 5.61i
+    description: Candara is a casual humanist sans with verticals showing a graceful
+      entasis on stems, high-branching arcades in the lowercase, large apertures in
+      all open forms, and unique ogee curves on diagonals. The resultant texture is
+      lively but not intrusive, and makes for a  friendly and readable text.
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Candarab.ttf
+  - family_name: Candara
+    type: Bold Italic
+    full_name: Candara Bold Italic
+    post_script_name: Candara-BoldItalic
+    version: 5.61i
+    description: Candara is a casual humanist sans with verticals showing a graceful
+      entasis on stems, high-branching arcades in the lowercase, large apertures in
+      all open forms, and unique ogee curves on diagonals. The resultant texture is
+      lively but not intrusive, and makes for a  friendly and readable text.
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Candaraz.ttf
+  - family_name: Candara
+    type: Italic
+    full_name: Candara Italic
+    post_script_name: Candara-Italic
+    version: 5.61i
+    description: Candara is a casual humanist sans with verticals showing a graceful
+      entasis on stems, high-branching arcades in the lowercase, large apertures in
+      all open forms, and unique ogee curves on diagonals. The resultant texture is
+      lively but not intrusive, and makes for a  friendly and readable text.
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Candarai.ttf
+  - family_name: Candara
+    type: Regular
+    full_name: Candara
+    post_script_name: Candara
+    version: 5.61i
+    description: Candara is a casual humanist sans with verticals showing a graceful
+      entasis on stems, high-branching arcades in the lowercase, large apertures in
+      all open forms, and unique ogee curves on diagonals. The resultant texture is
+      lively but not intrusive, and makes for a  friendly and readable text.
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Candara.ttf
+- name: Century
+  styles:
+  - family_name: Century
+    type: Regular
+    full_name: Century
+    post_script_name: Century
+    version: '1.25'
+    description: Another member of the Century family which was based on Century Expanded.
+      Designed to fulfill the need for a solid, legible face for printing schoolbooks.
+      It is wider and heavier than Century Expanded, there is also less contrast between
+      thick and thin strokes. First cut by Monotype in 1934 and based on versions
+      from ATF and Lanston Monotype. The sturdy nature of this typeface, coupled with
+      its inherent legibility, has made it a popular choice for setting books, newspapers
+      and magazines.
+    copyright: Digitized data copyright (C) 1992-1997 The Monotype Corporation. All
+      rights reserved. Century™ is a trademark of The Monotype Corporation which may
+      be registered in certain jurisdictions.
+    font: Century.ttf
+- name: Century Gothic
+  styles:
+  - family_name: Century Gothic
+    type: Bold
+    full_name: Century Gothic Bold
+    post_script_name: CenturyGothic-Bold
+    version: '2.35'
+    description: A design based on Monotype 20th Century, which was drawn by Sol Hess
+      between 1936 and 1947. Century Gothic maintains the basic design of 20th Century
+      but has an enlarged 'x' height and has been modified to ensure satisfactory
+      output from modern digital systems. The design is influenced by the geometric
+      style sans serif faces which were popular during the 1920's and 30's. Useful
+      for headlines and general display work and for small quantities of text, particularly
+      in advertising.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 1990-91 All Rights Reserved
+    font: Century Gothic Bold.ttf
+  - family_name: Century Gothic
+    type: Bold Italic
+    full_name: Century Gothic Bold Italic
+    post_script_name: CenturyGothic-BoldItalic
+    version: '2.35'
+    description: A design based on Monotype 20th Century, which was drawn by Sol Hess
+      between 1936 and 1947. Century Gothic maintains the basic design of 20th Century
+      but has an enlarged 'x' height and has been modified to ensure satisfactory
+      output from modern digital systems. The design is influenced by the geometric
+      style sans serif faces which were popular during the 1920's and 30's. Useful
+      for headlines and general display work and for small quantities of text, particularly
+      in advertising.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 1990-91 All Rights Reserved
+    font: Century Gothic Bold Italic.ttf
+  - family_name: Century Gothic
+    type: Italic
+    full_name: Century Gothic Italic
+    post_script_name: CenturyGothic-Italic
+    version: '2.35'
+    description: A design based on Monotype 20th Century, which was drawn by Sol Hess
+      between 1936 and 1947. Century Gothic maintains the basic design of 20th Century
+      but has an enlarged 'x' height and has been modified to ensure satisfactory
+      output from modern digital systems. The design is influenced by the geometric
+      style sans serif faces which were popular during the 1920's and 30's. Useful
+      for headlines and general display work and for small quantities of text, particularly
+      in advertising.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 1990-91 All Rights Reserved
+    font: Century Gothic Italic.ttf
+  - family_name: Century Gothic
+    type: Regular
+    full_name: Century Gothic
+    post_script_name: CenturyGothic
+    version: '2.35'
+    description: A design based on Monotype 20th Century, which was drawn by Sol Hess
+      between 1936 and 1947. Century Gothic maintains the basic design of 20th Century
+      but has an enlarged 'x' height and has been modified to ensure satisfactory
+      output from modern digital systems. The design is influenced by the geometric
+      style sans serif faces which were popular during the 1920's and 30's. Useful
+      for headlines and general display work and for small quantities of text, particularly
+      in advertising.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 1990-91 All Rights Reserved
+    font: Century Gothic.ttf
+- name: Century Schoolbook
+  styles:
+  - family_name: Century Schoolbook
+    type: Bold
+    full_name: Century Schoolbook Bold
+    post_script_name: CenturySchoolbook-Bold
+    version: '2.35'
+    description: Another member of the Century family which was based on Century Expanded.
+      Designed to fulfill the need for a solid, legible face for printing schoolbooks.
+      It is wider and heavier than Century Expanded, there is also less contrast between
+      thick and thin strokes. First cut by Monotype in 1934 and based on versions
+      from ATF and Lanston Monotype. The sturdy nature of this typeface, coupled with
+      its inherent legibility, has made it a popular choice for setting books, newspapers
+      and magazines.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 1990-91 All Rights Reserved.
+    font: Century Schoolbook Bold.ttf
+  - family_name: Century Schoolbook
+    type: Bold Italic
+    full_name: Century Schoolbook Bold Italic
+    post_script_name: CenturySchoolbook-BoldItalic
+    version: '2.35'
+    description: Another member of the Century family which was based on Century Expanded.
+      Designed to fulfill the need for a solid, legible face for printing schoolbooks.
+      It is wider and heavier than Century Expanded, there is also less contrast between
+      thick and thin strokes. First cut by Monotype in 1934 and based on versions
+      from ATF and Lanston Monotype. The sturdy nature of this typeface, coupled with
+      its inherent legibility, has made it a popular choice for setting books, newspapers
+      and magazines.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 1990-91 All Rights Reserved.
+    font: Century Schoolbook Bold Italic.ttf
+  - family_name: Century Schoolbook
+    type: Italic
+    full_name: Century Schoolbook Italic
+    post_script_name: CenturySchoolbook-Italic
+    version: '2.35'
+    description: Another member of the Century family which was based on Century Expanded.
+      Designed to fulfill the need for a solid, legible face for printing schoolbooks.
+      It is wider and heavier than Century Expanded, there is also less contrast between
+      thick and thin strokes. First cut by Monotype in 1934 and based on versions
+      from ATF and Lanston Monotype. The sturdy nature of this typeface, coupled with
+      its inherent legibility, has made it a popular choice for setting books, newspapers
+      and magazines.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 1990-91 All Rights Reserved.
+    font: Century Schoolbook Italic.ttf
+  - family_name: Century Schoolbook
+    type: Regular
+    full_name: Century Schoolbook
+    post_script_name: CenturySchoolbook
+    version: '2.35'
+    description: Another member of the Century family which was based on Century Expanded.
+      Designed to fulfill the need for a solid, legible face for printing schoolbooks.
+      It is wider and heavier than Century Expanded, there is also less contrast between
+      thick and thin strokes. First cut by Monotype in 1934 and based on versions
+      from ATF and Lanston Monotype. The sturdy nature of this typeface, coupled with
+      its inherent legibility, has made it a popular choice for setting books, newspapers
+      and magazines.
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc / Type Solutions Inc. 1990-91 All Rights Reserved.
+    font: Century Schoolbook.ttf
+- name: Colonna MT
+  styles:
+  - family_name: Colonna MT
+    type: Regular
+    full_name: Colonna MT
+    post_script_name: ColonnaMT
+    version: '1.51'
+    copyright: Copyright © The Monotype Corporation plc. 1992. All rights reserved.
+    font: ColonnaMT.ttf
+- name: Comic Sans MS
+  styles:
+  - family_name: Comic Sans MS
+    type: Bold
+    full_name: Comic Sans MS Bold
+    post_script_name: ComicSansMS-Bold
+    version: '2.10'
+    description: Designed by Microsoft's Vincent Connare, this is a face based on
+      the lettering from comic magazines. This casual but legible face has proved
+      very popular with a wide variety of people.
+    copyright: Copyright (c) 1995 Microsoft Corporation. All rights reserved.
+    font: ComicSansMSBold.ttf
+- name: Consolas
+  styles:
+  - family_name: Consolas
+    type: Bold
+    full_name: Consolas Bold
+    post_script_name: Consolas-Bold
+    version: 5.32i
+    description: Consolas is aimed for use in programming environments and other circumstances
+      where a monospaced font is specified. All characters have the same width, like
+      old typewriters, making it a good choice for personal and business correspondance.
+      The improved Windows font display allowed a design with proportions closer to
+      normal text than traditional monospaced fonts like Courier. This allows for
+      more comfortably reading of extended text on screen. OpenType features include
+      hanging or lining numerals; slashed, dotted and normal zeros; and alternative
+      shapes for a number of lowercase letters. The look of text can be tuned to personal
+      taste by varying the number of bars and waves.
+    copyright: "© 2012 Microsoft Corporation. All Rights Reserved."
+    font: Consolab.ttf
+  - family_name: Consolas
+    type: Bold Italic
+    full_name: Consolas Bold Italic
+    post_script_name: Consolas-BoldItalic
+    version: 5.32i
+    description: Consolas is aimed for use in programming environments and other circumstances
+      where a monospaced font is specified. All characters have the same width, like
+      old typewriters, making it a good choice for personal and business correspondance.
+      The improved Windows font display allowed a design with proportions closer to
+      normal text than traditional monospaced fonts like Courier. This allows for
+      more comfortably reading of extended text on screen. OpenType features include
+      hanging or lining numerals; slashed, dotted and normal zeros; and alternative
+      shapes for a number of lowercase letters. The look of text can be tuned to personal
+      taste by varying the number of bars and waves.
+    copyright: "© 2012 Microsoft Corporation. All Rights Reserved."
+    font: Consolaz.ttf
+  - family_name: Consolas
+    type: Italic
+    full_name: Consolas Italic
+    post_script_name: Consolas-Italic
+    version: 5.32i
+    description: Consolas is aimed for use in programming environments and other circumstances
+      where a monospaced font is specified. All characters have the same width, like
+      old typewriters, making it a good choice for personal and business correspondance.
+      The improved Windows font display allowed a design with proportions closer to
+      normal text than traditional monospaced fonts like Courier. This allows for
+      more comfortably reading of extended text on screen. OpenType features include
+      hanging or lining numerals; slashed, dotted and normal zeros; and alternative
+      shapes for a number of lowercase letters. The look of text can be tuned to personal
+      taste by varying the number of bars and waves.
+    copyright: "© 2012 Microsoft Corporation. All Rights Reserved."
+    font: Consolai.ttf
+  - family_name: Consolas
+    type: Regular
+    full_name: Consolas
+    post_script_name: Consolas
+    version: 5.32i
+    description: Consolas is aimed for use in programming environments and other circumstances
+      where a monospaced font is specified. All characters have the same width, like
+      old typewriters, making it a good choice for personal and business correspondance.
+      The improved Windows font display allowed a design with proportions closer to
+      normal text than traditional monospaced fonts like Courier. This allows for
+      more comfortably reading of extended text on screen. OpenType features include
+      hanging or lining numerals; slashed, dotted and normal zeros; and alternative
+      shapes for a number of lowercase letters. The look of text can be tuned to personal
+      taste by varying the number of bars and waves.
+    copyright: "© 2012 Microsoft Corporation. All Rights Reserved."
+    font: Consola.ttf
+- name: Constantia
+  styles:
+  - family_name: Constantia
+    type: Bold
+    full_name: Constantia Bold
+    post_script_name: Constantia-Bold
+    version: 5.90i
+    description: Constantia is a modulated wedge-serif typeface designed primarily
+      for continuous text in both electronic and paper publishing. The design responds
+      to the recent narrowing of the gap between screen readability and traditional
+      print media, exploiting specific aspects of the most recent advances in ClearType
+      rendering, such as sub-pixel positioning. The classic proportions of relatively
+      small x-height and long extenders make Constantia ideal for book and journal
+      publishing, while the slight squareness and open counters ensure that it remains
+      legible even at small sizes.
+    copyright: "© 2009 Microsoft Corporation. All Rights Reserved."
+    font: Constanb.TTF
+  - family_name: Constantia
+    type: Bold Italic
+    full_name: Constantia Bold Italic
+    post_script_name: Constantia-BoldItalic
+    version: 5.90i
+    description: Constantia is a modulated wedge-serif typeface designed primarily
+      for continuous text in both electronic and paper publishing. The design responds
+      to the recent narrowing of the gap between screen readability and traditional
+      print media, exploiting specific aspects of the most recent advances in ClearType
+      rendering, such as sub-pixel positioning. The classic proportions of relatively
+      small x-height and long extenders make Constantia ideal for book and journal
+      publishing, while the slight squareness and open counters ensure that it remains
+      legible even at small sizes.
+    copyright: "© 2009 Microsoft Corporation. All Rights Reserved."
+    font: Constanz.TTF
+  - family_name: Constantia
+    type: Italic
+    full_name: Constantia Italic
+    post_script_name: Constantia-Italic
+    version: 5.90i
+    description: Constantia is a modulated wedge-serif typeface designed primarily
+      for continuous text in both electronic and paper publishing. The design responds
+      to the recent narrowing of the gap between screen readability and traditional
+      print media, exploiting specific aspects of the most recent advances in ClearType
+      rendering, such as sub-pixel positioning. The classic proportions of relatively
+      small x-height and long extenders make Constantia ideal for book and journal
+      publishing, while the slight squareness and open counters ensure that it remains
+      legible even at small sizes.
+    copyright: "© 2009 Microsoft Corporation. All Rights Reserved."
+    font: Constani.TTF
+  - family_name: Constantia
+    type: Regular
+    full_name: Constantia
+    post_script_name: Constantia
+    version: 5.90i
+    description: Constantia is a modulated wedge-serif typeface designed primarily
+      for continuous text in both electronic and paper publishing. The design responds
+      to the recent narrowing of the gap between screen readability and traditional
+      print media, exploiting specific aspects of the most recent advances in ClearType
+      rendering, such as sub-pixel positioning. The classic proportions of relatively
+      small x-height and long extenders make Constantia ideal for book and journal
+      publishing, while the slight squareness and open counters ensure that it remains
+      legible even at small sizes.
+    copyright: "© 2009 Microsoft Corporation. All Rights Reserved."
+    font: Constan.TTF
+- name: Copperplate Gothic Bold
+  styles:
+  - family_name: Copperplate Gothic Bold
+    type: Regular
+    full_name: Copperplate Gothic Bold
+    post_script_name: CopperplateGothic-Bold
+    version: '1.51'
+    copyright: Data copyright © URW Software & Type GbmH., additional data copyright
+      The Font Bureau, Inc. Copyright 1994 Microsoft Corporation. All rights reserved.
+    font: CopperplateGothicBold.ttf
+- name: Corbel
+  styles:
+  - family_name: Corbel
+    type: Bold
+    full_name: Corbel Bold
+    post_script_name: Corbel-Bold
+    version: 5.61i
+    description: Corbel is designed to give an uncluttered and clean appearance on
+      screen. The letter forms are open with soft, flowing curves. It is legible,
+      clear and functional at small sizes. At larger sizes the detailing and style
+      of the shapes is more apparent resulting in a modern sans serif type with a
+      wide range of possible uses.
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Corbelb.ttf
+  - family_name: Corbel
+    type: Bold Italic
+    full_name: Corbel Bold Italic
+    post_script_name: Corbel-BoldItalic
+    version: 5.61i
+    description: Corbel is designed to give an uncluttered and clean appearance on
+      screen. The letter forms are open with soft, flowing curves. It is legible,
+      clear and functional at small sizes. At larger sizes the detailing and style
+      of the shapes is more apparent resulting in a modern sans serif type with a
+      wide range of possible uses.
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Corbelz.ttf
+  - family_name: Corbel
+    type: Italic
+    full_name: Corbel Italic
+    post_script_name: Corbel-Italic
+    version: 5.61i
+    description: Corbel is designed to give an uncluttered and clean appearance on
+      screen. The letter forms are open with soft, flowing curves. It is legible,
+      clear and functional at small sizes. At larger sizes the detailing and style
+      of the shapes is more apparent resulting in a modern sans serif type with a
+      wide range of possible uses.
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Corbeli.ttf
+  - family_name: Corbel
+    type: Regular
+    full_name: Corbel
+    post_script_name: Corbel
+    version: 5.61i
+    description: Corbel is designed to give an uncluttered and clean appearance on
+      screen. The letter forms are open with soft, flowing curves. It is legible,
+      clear and functional at small sizes. At larger sizes the detailing and style
+      of the shapes is more apparent resulting in a modern sans serif type with a
+      wide range of possible uses.
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Corbel.ttf
+- name: Curlz MT
+  styles:
+  - family_name: Curlz MT
+    type: Regular
+    full_name: Curlz MT
+    post_script_name: CurlzMT
+    version: '1.01'
+    description: Curlz was designed by Steve Matteson and Carl Crossgrove in 1995.
+      For a unique, festive touch, add a little Curlz to posters, flyers, invitations,
+      menus and tee shirts.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Curlz™ is a trademark of The Monotype Corporation which may be registered
+      in certain jurisdictions.
+    font: CurlzMT.ttf
+- name: DengXian
+  styles:
+  - family_name: DengXian
+    type: Bold
+    full_name: DengXian Bold
+    post_script_name: DengXian-Bold
+    version: 1.05; Mac
+    copyright: Copyright(c) Beijing Founder Electronics Co.,Ltd.2012
+    font: Dengb.ttf
+  - family_name: DengXian
+    type: Regular
+    full_name: DengXian Regular
+    post_script_name: DengXian-Regular
+    version: 1.11; Mac
+    copyright: Copyright(c) Beijing Founder Electronics Co.,Ltd.2012
+    font: Deng.ttf
+- name: DengXian Light
+  styles:
+  - family_name: DengXian Light
+    type: Regular
+    preferred_family_name: DengXian
+    preferred_type: Light
+    full_name: DengXian Light
+    post_script_name: DengXian-Light
+    version: 1.11; Mac
+    copyright: Copyright(c) Beijing Founder Electronics Co.,Ltd.2012
+    font: Dengl.ttf
+- name: Desdemona
+  styles:
+  - family_name: Desdemona
+    type: Regular
+    full_name: Desdemona
+    post_script_name: Desdemona
+    version: '1.53'
+    copyright: Typeface © 1992 The Font Bureau, Inc., Portions © 1992 Microsoft Corp.
+      All rights reserved.
+    font: Desdemona.ttf
+- name: Edwardian Script ITC
+  styles:
+  - family_name: Edwardian Script ITC
+    type: Regular
+    full_name: Edwardian Script ITC
+    post_script_name: EdwardianScriptITC
+    version: '1.15'
+    copyright: Copyright (c) International Typeface Corporation 1997.  Portions Copyright
+      (c) Microsoft Corporation 1997.  All rights reserved.
+    font: EdwardianScriptITC.ttf
+- name: Engravers MT
+  styles:
+  - family_name: Engravers MT
+    type: Bold
+    full_name: Engravers MT Bold
+    post_script_name: EngraversMT-Bold
+    version: '1.60'
+    copyright: Design and data by The Monotype Corporation. © 1993-1999. Microsoft
+      Corporation. All rights reserved.
+    font: EngraversMTBold.ttf
+  - family_name: Engravers MT
+    type: Regular
+    full_name: Engravers MT
+    post_script_name: EngraversMT
+    version: '1.60'
+    copyright: Design and data by The Monotype Corporation. © 1993-1999. Microsoft
+      Corporation. All rights reserved.
+    font: EngraversMT.ttf
+- name: Eurostile
+  styles:
+  - family_name: Eurostile
+    type: Bold
+    full_name: Eurostile Bold
+    post_script_name: EurostileBold
+    version: '1.51'
+    copyright: Typeface © 1992 Fonderia Caratteri Svizzera Walter Fruttiger A.G. Data
+      © 1992 URW. Portions © 1992 Microsoft Corp. All rights reserved.
+    font: Eurostile Bold.ttf
+  - family_name: Eurostile
+    type: Regular
+    full_name: Eurostile
+    post_script_name: EurostileRegular
+    version: '5.00'
+    copyright: Typeface © 1992 Fonderia Caratteri Svizzera Walter Fruttiger A.G. Data
+      © 1992 URW. Portions © 1992 Microsoft Corp. All rights reserved.
+    font: Eurostile.ttf
+- name: FangSong
+  styles:
+  - family_name: FangSong
+    type: Regular
+    full_name: FangSong
+    post_script_name: FangSong
+    version: 5.01i
+    copyright: "© Beijing ZhongYi Electronics Co., 1995-2005, All rights reserved"
+    font: Fangsong.ttf
+- name: Footlight MT Light
+  styles:
+  - family_name: Footlight MT Light
+    type: Regular
+    full_name: Footlight MT Light
+    post_script_name: FootlightMTLight
+    version: '1.51'
+    copyright: Footlight © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc/Type Solutions Inc. 1990 - 1992 All rights reserved.
+    font: FootlightMTLight.ttf
+- name: Franklin Gothic Book
+  styles:
+  - family_name: Franklin Gothic Book
+    type: Italic
+    full_name: Franklin Gothic Book Italic
+    post_script_name: FranklinGothic-BookItalic
+    version: '2.01'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Book Italic.ttf
+  - family_name: Franklin Gothic Book
+    type: Regular
+    full_name: Franklin Gothic Book
+    post_script_name: FranklinGothic-Book
+    version: '2.01'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Book.ttf
+- name: Franklin Gothic Demi
+  styles:
+  - family_name: Franklin Gothic Demi
+    type: Italic
+    full_name: Franklin Gothic Demi Italic
+    post_script_name: FranklinGothic-DemiItalic
+    version: '2.00'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Demi Italic.ttf
+  - family_name: Franklin Gothic Demi
+    type: Regular
+    full_name: Franklin Gothic Demi
+    post_script_name: FranklinGothic-Demi
+    version: '2.00'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Demi.ttf
+- name: Franklin Gothic Demi Cond
+  styles:
+  - family_name: Franklin Gothic Demi Cond
+    type: Regular
+    full_name: Franklin Gothic Demi Cond
+    post_script_name: FranklinGothic-DemiCond
+    version: '2.00'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Demi Cond.ttf
+- name: Franklin Gothic Heavy
+  styles:
+  - family_name: Franklin Gothic Heavy
+    type: Italic
+    full_name: Franklin Gothic Heavy Italic
+    post_script_name: FranklinGothic-HeavyItalic
+    version: '2.00'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Heavy Italic.ttf
+  - family_name: Franklin Gothic Heavy
+    type: Regular
+    full_name: Franklin Gothic Heavy
+    post_script_name: FranklinGothic-Heavy
+    version: '2.00'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Heavy.ttf
+- name: Franklin Gothic Medium
+  styles:
+  - family_name: Franklin Gothic Medium
+    type: Italic
+    full_name: Franklin Gothic Medium Italic
+    post_script_name: FranklinGothic-MediumItalic
+    version: '5.00'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Medium Italic.ttf
+  - family_name: Franklin Gothic Medium
+    type: Regular
+    full_name: Franklin Gothic Medium
+    post_script_name: FranklinGothic-Medium
+    version: '5.01'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Medium.ttf
+- name: Franklin Gothic Medium Cond
+  styles:
+  - family_name: Franklin Gothic Medium Cond
+    type: Regular
+    full_name: Franklin Gothic Medium Cond
+    post_script_name: FranklinGothic-MediumCond
+    version: '2.00'
+    description: 'Designed in 1902 by Morris Fuller Benton for the American Type Founders
+      company, Franklin Gothic still reigns as one of the most-widely used sans serif
+      typefaces. Originally issued in only one weight, the ATF version of Franklin
+      Gothic was eventually expanded to include five additional weights, but no light
+      or intermediate weights were ever developed. In 1979, under license from ATF,
+      ITC developed four new weights in roman and italic: book, medium, demi and heavy.
+      Designed by Victor Caruso, ITC’s new weights matched the original face’s characteristics,
+      but featured a slightly enlarged lowercase x-height. ITC Franklin Gothic also
+      features a slightly condensed lowercase a-z alphabet. In 1991, ITC commissioned
+      the Font Bureau in Boston to create condensed, compressed and extra compressed
+      versions of ITC Franklin Gothic, which increased the flexibility and usefulness
+      of the design.'
+    copyright: ITC Franklin Gothic is a trademark of The International Typeface Corporation
+      which may be registered in certain jurisdictions. Portions copyright Microsoft
+      Corporation.  All rights reserved.
+    font: Franklin Gothic Medium Cond.ttf
+- name: Gabriola
+  styles:
+  - family_name: Gabriola
+    type: Regular
+    full_name: Gabriola
+    post_script_name: Gabriola
+    version: 5.92i
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Gabriola.ttf
+- name: Garamond
+  styles:
+  - family_name: Garamond
+    type: Bold
+    full_name: Garamond Bold
+    post_script_name: Garamond-Bold
+    version: '2.40'
+    description: Monotype Drawing Office 1922. This typeface is based on roman types
+      cut by Jean Jannon in 1615. Jannon followed the designs of Claude Garamond which
+      had been cut in the previous century. Garamond's types were, in turn, based
+      on those used by Aldus Manutius in 1495 and cut by Francesco Griffo. The italic
+      is based on types cut in France circa 1557 by Robert Granjon. Garamond is a
+      beautiful typeface with an air of informality which looks good in a wide range
+      of applications. It works particularly well in books and lengthy text settings.
+    copyright: Digitized data copyright Monotype Typography, Ltd 1991-1995. All rights
+      reserved. Monotype Garamond® is a trademark of Monotype Typography, Ltd which
+      may be registered in certain jurisdictions.
+    font: GARABD.TTF
+  - family_name: Garamond
+    type: Italic
+    full_name: Garamond Italic
+    post_script_name: Garamond-Italic
+    version: '2.40'
+    description: Monotype Drawing Office 1922. This typeface is based on roman types
+      cut by Jean Jannon in 1615. Jannon followed the designs of Claude Garamond which
+      had been cut in the previous century. Garamond's types were, in turn, based
+      on those used by Aldus Manutius in 1495 and cut by Francesco Griffo. The italic
+      is based on types cut in France circa 1557 by Robert Granjon. Garamond is a
+      beautiful typeface with an air of informality which looks good in a wide range
+      of applications. It works particularly well in books and lengthy text settings.
+    copyright: Digitized data copyright Monotype Typography, Ltd 1991-1995. All rights
+      reserved. Monotype Garamond® is a trademark of Monotype Typography, Ltd which
+      may be registered in certain jurisdictions.
+    font: GARAIT.TTF
+  - family_name: Garamond
+    type: Regular
+    full_name: Garamond
+    post_script_name: Garamond
+    version: '2.40'
+    description: Monotype Drawing Office 1922. This typeface is based on roman types
+      cut by Jean Jannon in 1615. Jannon followed the designs of Claude Garamond which
+      had been cut in the previous century. Garamond's types were, in turn, based
+      on those used by Aldus Manutius in 1495 and cut by Francesco Griffo. The italic
+      is based on types cut in France circa 1557 by Robert Granjon. Garamond is a
+      beautiful typeface with an air of informality which looks good in a wide range
+      of applications. It works particularly well in books and lengthy text settings.
+    copyright: Digitized data copyright Monotype Typography, Ltd 1991-1995. All rights
+      reserved. Monotype Garamond® is a trademark of Monotype Typography, Ltd which
+      may be registered in certain jurisdictions.
+    font: GARA.TTF
+- name: Gill Sans MT
+  styles:
+  - family_name: Gill Sans MT
+    type: Bold
+    full_name: Gill Sans MT Bold
+    post_script_name: GillSansMT-Bold
+    version: '1.65'
+    description: Monotype Type Drawing Office 1928. Gill studied under the renowned
+      calligrapher, Edward Johnston, the designer of the London Underground sans serif
+      typeface. This influenced Gill who later experimented with sans serif designs,
+      and in due course produced a set of capital letters. These became Monotype series
+      231, produced in 1923, and the forerunner of the extensive Gill Sans range now
+      available. A twentieth century sans serif that has a simplicity of form which
+      does not reject traditional forms and proportions, and gives the face a humanist
+      feel. The lighter weights are highly readable in text and suitable for magazine
+      and book work, whereas the heavier weights are best used for display in advertising,
+      packaging, and labels.
+    copyright: Digitized data copyright © 1997 The Monotype Corporation, Inc. All
+      rights reserved. Gill Sans® is a trademark of The Monotype Corporation, Inc.
+      which may be registered in certain jurisdictions.
+    font: Gill Sans MT Bold.ttf
+  - family_name: Gill Sans MT
+    type: Bold Italic
+    full_name: Gill Sans MT Bold Italic
+    post_script_name: GillSansMT-BoldItalic
+    version: '1.65'
+    description: Monotype Type Drawing Office 1928. Gill studied under the renowned
+      calligrapher, Edward Johnston, the designer of the London Underground sans serif
+      typeface. This influenced Gill who later experimented with sans serif designs,
+      and in due course produced a set of capital letters. These became Monotype series
+      231, produced in 1923, and the forerunner of the extensive Gill Sans range now
+      available. A twentieth century sans serif that has a simplicity of form which
+      does not reject traditional forms and proportions, and gives the face a humanist
+      feel. The lighter weights are highly readable in text and suitable for magazine
+      and book work, whereas the heavier weights are best used for display in advertising,
+      packaging, and labels.
+    copyright: Digitized data copyright © 1997 The Monotype Corporation, Inc. All
+      rights reserved. Gill Sans® is a trademark of The Monotype Corporation, Inc.
+      which may be registered in certain jurisdictions.
+    font: Gill Sans MT Bold Italic.ttf
+  - family_name: Gill Sans MT
+    type: Italic
+    full_name: Gill Sans MT Italic
+    post_script_name: GillSansMT-Italic
+    version: '1.65'
+    description: Monotype Type Drawing Office 1928. Gill studied under the renowned
+      calligrapher, Edward Johnston, the designer of the London Underground sans serif
+      typeface. This influenced Gill who later experimented with sans serif designs,
+      and in due course produced a set of capital letters. These became Monotype series
+      231, produced in 1923, and the forerunner of the extensive Gill Sans range now
+      available. A twentieth century sans serif that has a simplicity of form which
+      does not reject traditional forms and proportions, and gives the face a humanist
+      feel. The lighter weights are highly readable in text and suitable for magazine
+      and book work, whereas the heavier weights are best used for display in advertising,
+      packaging, and labels.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Gill Sans® is a trademark of The Monotype Corporation which may be
+      registered in certain jurisdictions.
+    font: Gill Sans MT Italic.ttf
+  - family_name: Gill Sans MT
+    type: Regular
+    full_name: Gill Sans MT
+    post_script_name: GillSansMT
+    version: '1.65'
+    description: Monotype Type Drawing Office 1928. Gill studied under the renowned
+      calligrapher, Edward Johnston, the designer of the London Underground sans serif
+      typeface. This influenced Gill who later experimented with sans serif designs,
+      and in due course produced a set of capital letters. These became Monotype series
+      231, produced in 1923, and the forerunner of the extensive Gill Sans range now
+      available. A twentieth century sans serif that has a simplicity of form which
+      does not reject traditional forms and proportions, and gives the face a humanist
+      feel. The lighter weights are highly readable in text and suitable for magazine
+      and book work, whereas the heavier weights are best used for display in advertising,
+      packaging, and labels.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Gill Sans® is a trademark of The Monotype Corporation which may be
+      registered in certain jurisdictions.
+    font: Gill Sans MT.ttf
+- name: Gill Sans MT Condensed
+  styles:
+  - family_name: Gill Sans MT Condensed
+    type: Regular
+    full_name: Gill Sans MT Condensed
+    post_script_name: GillSansMT-Condensed
+    version: '1.65'
+    description: Monotype Type Drawing Office 1928. Gill studied under the renowned
+      calligrapher, Edward Johnston, the designer of the London Underground sans serif
+      typeface. This influenced Gill who later experimented with sans serif designs,
+      and in due course produced a set of capital letters. These became Monotype series
+      231, produced in 1923, and the forerunner of the extensive Gill Sans range now
+      available. A twentieth century sans serif that has a simplicity of form which
+      does not reject traditional forms and proportions, and gives the face a humanist
+      feel. The lighter weights are highly readable in text and suitable for magazine
+      and book work, whereas the heavier weights are best used for display in advertising,
+      packaging, and labels.
+    copyright: Digitized data copyright © 1997 The Monotype Corporation, Inc. All
+      rights reserved. Gill Sans® is a trademark of The Monotype Corporation, Inc.
+      which may be registered in certain jurisdictions.
+    font: Gill Sans MT Condensed.ttf
+- name: Gill Sans MT Ext Condensed Bold
+  styles:
+  - family_name: Gill Sans MT Ext Condensed Bold
+    type: Regular
+    full_name: Gill Sans MT Ext Condensed Bold
+    post_script_name: GillSansMT-ExtraCondensedBold
+    version: '1.65'
+    description: Monotype Type Drawing Office 1928. Gill studied under the renowned
+      calligrapher, Edward Johnston, the designer of the London Underground sans serif
+      typeface. This influenced Gill who later experimented with sans serif designs,
+      and in due course produced a set of capital letters. These became Monotype series
+      231, produced in 1923, and the forerunner of the extensive Gill Sans range now
+      available. A twentieth century sans serif that has a simplicity of form which
+      does not reject traditional forms and proportions, and gives the face a humanist
+      feel. The lighter weights are highly readable in text and suitable for magazine
+      and book work, whereas the heavier weights are best used for display in advertising,
+      packaging, and labels.
+    copyright: Digitized data copyright (C) 1991-1997 The Monotype Corporation. All
+      rights reserved. Gill Sans® is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdicions.
+    font: Gill Sans MT Ext Condensed Bold.ttf
+- name: Gill Sans Ultra Bold
+  styles:
+  - family_name: Gill Sans Ultra Bold
+    type: Regular
+    full_name: Gill Sans Ultra Bold
+    post_script_name: GillSans-UltraBold
+    version: '1.65'
+    description: Monotype Type Drawing Office 1928. Gill studied under the renowned
+      calligrapher, Edward Johnston, the designer of the London Underground sans serif
+      typeface. This influenced Gill who later experimented with sans serif designs,
+      and in due course produced a set of capital letters. These became Monotype series
+      231, produced in 1923, and the forerunner of the extensive Gill Sans range now
+      available. A twentieth century sans serif that has a simplicity of form which
+      does not reject traditional forms and proportions, and gives the face a humanist
+      feel. The lighter weights are highly readable in text and suitable for magazine
+      and book work, whereas the heavier weights are best used for display in advertising,
+      packaging, and labels.
+    copyright: Digitized data copyright © 1997 The Monotype Corporation, Inc. All
+      rights reserved. Gill Sans® is a trademark of The Monotype Corporation, Inc.
+      which may be registered in certain jurisdictions.
+    font: GillSansUltraBold.ttf
+- name: Gloucester MT Extra Condensed
+  styles:
+  - family_name: Gloucester MT Extra Condensed
+    type: Regular
+    full_name: Gloucester MT Extra Condensed
+    post_script_name: GloucesterMT-ExtraCondensed
+    version: '1.51'
+    copyright: Typeface data Copyright 1992-94 The Monotype Corporation. Copyright
+      1994 Microsoft Corporation. All rights reserved.
+    font: GloucesterMTExtraCondensed.ttf
+- name: Goudy Old Style
+  styles:
+  - family_name: Goudy Old Style
+    type: Bold
+    full_name: Goudy Old Style Bold
+    post_script_name: GoudyOldStyleT-Bold
+    version: '1.51'
+    copyright: Data by URW, Type Solutions, Inc. © 1993. Microsoft Corporation. All
+      rights reserved.
+    font: Goudy Old Style Bold.ttf
+  - family_name: Goudy Old Style
+    type: Italic
+    full_name: Goudy Old Style Italic
+    post_script_name: GoudyOldStyleT-Italic
+    version: '1.51'
+    copyright: Data by URW, Type Solutions, Inc. © 1993. Microsoft Corporation. All
+      rights reserved.
+    font: Goudy Old Style Italic.ttf
+  - family_name: Goudy Old Style
+    type: Regular
+    full_name: Goudy Old Style
+    post_script_name: GoudyOldStyleT-Regular
+    version: '1.51'
+    copyright: Data by URW, Type Solutions, Inc. © 1993. Microsoft Corporation. All
+      rights reserved.
+    font: Goudy Old Style.ttf
+- name: HGMaruGothicMPRO
+  styles:
+  - family_name: HGMaruGothicMPRO
+    type: Regular
+    full_name: HGMaruGothicMPRO
+    post_script_name: HGMaruGothicMPRO
+    version: '5.02'
+    copyright: "(C)2009 data:RICOH Co.,Ltd. typeface:RYOBI IMAGIX CO."
+    font: HGRSMP.TTF
+- name: Haettenschweiler
+  styles:
+  - family_name: Haettenschweiler
+    type: Regular
+    full_name: Haettenschweiler
+    post_script_name: Haettenschweiler
+    version: '0.80'
+    description: Haettenschweiler derives from a more condensed typeface, called Schmalfette
+      Grotesk, first shown in the early 1960s in a splendid book called Lettera by
+      Walter Haettenschweiler and Armin Haab. Schmalfette Grotesk was a very condensed,
+      very bold alphabet of all capitals – schmalfette means "bold condensed" in German,
+      and grotesk indicates it is without serifs.
+    copyright: Data by Eraman Ltd., and Monotype Typography Inc. © 1995. Microsoft
+      Corporation. All rights reserved.
+    font: Haettenschweiler.ttf
+- name: Harrington
+  styles:
+  - family_name: Harrington
+    type: Regular
+    full_name: Harrington
+    post_script_name: Harrington
+    version: '1.51'
+    copyright: "©1992. The Font Bureau, Inc. Portions © 1992 Microsoft Corp. All rights
+      reserved."
+    font: Harrington.ttf
+- name: Imprint MT Shadow
+  styles:
+  - family_name: Imprint MT Shadow
+    type: Regular
+    full_name: Imprint MT Shadow
+    post_script_name: ImprintMT-Shadow
+    version: '1.51'
+    copyright: Design and data by The Monotype Corporation. © 1993. Microsoft Corporation.
+      all rights reserved.
+    font: ImprintMTShadow.ttf
+- name: KaiTi
+  styles:
+  - family_name: KaiTi
+    type: Regular
+    full_name: KaiTi
+    post_script_name: KaiTi
+    version: 5.01i
+    copyright: "© Beijing ZhongYi Electronics Co., 1995-2005, All rights reserved"
+    font: Kaiti.ttf
+- name: Kino MT
+  styles:
+  - family_name: Kino MT
+    type: Regular
+    full_name: Kino MT
+    post_script_name: KinoMT
+    version: '1.51'
+    copyright: Copyright © The Monotype Corporation plc. 1992. All rights reserved
+    font: KinoMT.ttf
+- name: Lucida Blackletter
+  styles:
+  - family_name: Lucida Blackletter
+    type: Regular
+    full_name: Lucida Blackletter
+    post_script_name: LucidaBlackletter
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. All Rights Reserved. © 1990-1991 Type
+      Solutions, Inc. All Rights Reserved."
+    font: LucidaBlackletter.ttf
+- name: Lucida Bright
+  styles:
+  - family_name: Lucida Bright
+    type: Demibold
+    full_name: Lucida Bright Demibold
+    post_script_name: LucidaBright-Demi
+    version: '1.69'
+    copyright: "© 1991 by Bigelow & Holmes Inc. Pat. Des. 289,422. All Rights Reserved.
+      © 1990-1991 Type Solutions, Inc. All Rights Reserved."
+    font: LucidaBrightDemibold.ttf
+  - family_name: Lucida Bright
+    type: Demibold Italic
+    full_name: Lucida Bright Demibold Italic
+    post_script_name: LucidaBright-DemiItalic
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. Pat. Des. 289,773. All Rights Reserved.
+      © 1990-1991 Type Solutions, Inc. All Rights Reserved."
+    font: LucidaBrightDemiboldItalic.ttf
+  - family_name: Lucida Bright
+    type: Italic
+    full_name: Lucida Bright Italic
+    post_script_name: LucidaBright-Italic
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. Pat. Des. 289,773. All Rights Reserved.
+      © 1990-1991 Type Solutions, Inc. All Rights Reserved."
+    font: LucidaBrightItalic.ttf
+  - family_name: Lucida Bright
+    type: Regular
+    full_name: Lucida Bright
+    post_script_name: LucidaBright
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. Pat. Des. 289,421. All Rights Reserved.
+      © 1990-1991 Type Solutions, Inc. All Rights Reserved."
+    font: LucidaBright.ttf
+- name: Lucida Calligraphy
+  styles:
+  - family_name: Lucida Calligraphy
+    type: Italic
+    full_name: Lucida Calligraphy Italic
+    post_script_name: LucidaCalligraphy-Italic
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes. All Rights Reserved. © 1990-1991 Type Solutions,
+      Inc. All Rights Reserved."
+    font: LucidaCalligraphyItalic.ttf
+- name: Lucida Console
+  styles:
+  - family_name: Lucida Console
+    type: Regular
+    full_name: Lucida Console
+    post_script_name: LucidaConsole
+    version: '5.00'
+    copyright: Copyright © 1993 Bigelow & Holmes Inc. All rights reserved.
+    font: Lucida Console.ttf
+- name: Lucida Fax
+  styles:
+  - family_name: Lucida Fax
+    type: Demibold
+    full_name: Lucida Fax Demibold
+    post_script_name: LucidaFax-Demi
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. Pat. 289,422. All Rights Reserved. ©
+      1990-1991 Type Solutions, Inc. All Rights Reserved."
+    font: LucidaFaxDemibold.ttf
+  - family_name: Lucida Fax
+    type: Demibold Italic
+    full_name: Lucida Fax Demibold Italic
+    post_script_name: LucidaFax-DemiItalic
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc.  All Rights Reserved. © 1990-1991 Type
+      Solutions, Inc. All Rights Reserved."
+    font: LucidaFaxDemiboldItalic.ttf
+  - family_name: Lucida Fax
+    type: Italic
+    full_name: Lucida Fax Italic
+    post_script_name: LucidaFax-Italic
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. Pat. 289,773. All Rights Reserved. ©
+      1990-1991 Type Solutions, Inc. All Rights Reserved."
+    font: LucidaFaxItalic.ttf
+  - family_name: Lucida Fax
+    type: Regular
+    full_name: Lucida Fax Regular
+    post_script_name: LucidaFax
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. Pat. 289,421. All Rights Reserved. ©
+      1990-1991 Type Solutions, Inc. All Rights Reserved."
+    font: LucidaFaxRegular.ttf
+- name: Lucida Handwriting
+  styles:
+  - family_name: Lucida Handwriting
+    type: Italic
+    full_name: Lucida Handwriting Italic
+    post_script_name: LucidaHandwriting-Italic
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. All Rights Reserved. Pat. Pend. © 1990-1991
+      Type Solutions, Inc. All Rights Reserved."
+    font: LucidaHandwritingItalic.ttf
+- name: Lucida Sans
+  styles:
+  - family_name: Lucida Sans
+    type: Demibold Italic
+    full_name: Lucida Sans Demibold Italic
+    post_script_name: LucidaSans-DemiItalic
+    version: '1.67'
+    copyright: "© 1991 by Bigelow & Holmes Inc. All Rights Reserved. © 1990-1991 Type
+      Solutions, Inc. All Rights Reserved."
+    font: Lucida Sans Demibold Italic.ttf
+  - family_name: Lucida Sans
+    type: Demibold Roman
+    full_name: Lucida Sans Demibold Roman
+    post_script_name: LucidaSans-Demi
+    version: '1.67'
+    copyright: "© 1991 Bigelow & Holmes Inc. All Rights Reserved. © 1990-1991 Type
+      Solutions, Inc. All Rights Reserved."
+    font: Lucida Sans Demibold Roman.ttf
+  - family_name: Lucida Sans
+    type: Italic
+    full_name: Lucida Sans Italic
+    post_script_name: LucidaSans-Italic
+    version: '1.67'
+    copyright: "© 1991 Bigelow & Holmes Inc. All Rights Reserved. © 1990-1991 Type
+      Solutions, Inc. All Rights Reserved."
+    font: Lucida Sans Italic.ttf
+  - family_name: Lucida Sans
+    type: Regular
+    full_name: Lucida Sans Regular
+    post_script_name: LucidaSans
+    version: '1.67'
+    copyright: "© 1991 Bigelow & Holmes Inc. Pat. Des. 289,420. All Rights Reserved.
+      © 1990-1991 Type Solutions, Inc. All Rights Reserved."
+    font: Lucida Sans.ttf
+- name: Lucida Sans Typewriter
+  styles:
+  - family_name: Lucida Sans Typewriter
+    type: Bold
+    full_name: Lucida Sans Typewriter Bold
+    post_script_name: LucidaSans-TypewriterBold
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. All Rights Reserved. © 1990-1991 Type
+      Solutions, Inc. All Rights Reserved."
+    font: LucidaSansTypewriterBold.ttf
+  - family_name: Lucida Sans Typewriter
+    type: Bold Oblique
+    full_name: Lucida Sans Typewriter Bold Oblique
+    post_script_name: LucidaSans-TypewriterBoldOblique
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. All Rights Reserved. © 1990-1991 Type
+      Solutions, Inc. All Rights Reserved."
+    font: LucidaSansTypewriterBoldOblique.ttf
+  - family_name: Lucida Sans Typewriter
+    type: Oblique
+    full_name: Lucida Sans Typewriter Oblique
+    post_script_name: LucidaSans-TypewriterOblique
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. All Rights Reserved. © 1990-1991 Type
+      Solutions, Inc. All Rights Reserved."
+    font: LucidaSansTypewriterOblique.ttf
+  - family_name: Lucida Sans Typewriter
+    type: Regular
+    full_name: Lucida Sans Typewriter Regular
+    post_script_name: LucidaSans-Typewriter
+    version: '1.69'
+    copyright: "© 1991 Bigelow & Holmes Inc. Pat. Des. 289,420. All Rights Reserved.
+      © 1990-1991 Type Solutions, Inc. All Rights Reserved."
+    font: LucidaSansTypewriterRegular.ttf
+- name: Lucida Sans Unicode
+  styles:
+  - family_name: Lucida Sans Unicode
+    type: Regular
+    full_name: Lucida Sans Unicode
+    post_script_name: LucidaSansUnicode
+    version: '5.00'
+    description: 'Characteristics:'
+    copyright: Copyright © 1993 Bigelow & Holmes Inc. All rights reserved. Pat. Des.
+      289,420. Pats. Pend.
+    font: Lucida Sans Unicode.ttf
+- name: MS Reference Sans Serif
+  styles:
+  - family_name: MS Reference Sans Serif
+    type: Regular
+    full_name: MS Reference Sans Serif
+    post_script_name: MSReferenceSansSerif
+    version: '2.00'
+    copyright: Typeface and data © 1996 Microsoft Corporation. All Rights Reserved.
+    font: MS Reference Sans Serif.ttf
+- name: MS Reference Specialty
+  styles:
+  - family_name: MS Reference Specialty
+    type: Regular
+    full_name: MS Reference Specialty
+    post_script_name: MSReferenceSpecialty
+    version: '1.00'
+    copyright: Digitized data copyright (C) 1998 The Monotype Corporation. All rights
+      reserved.
+    font: MS Reference Specialty.ttf
+- name: MT Extra
+  styles:
+  - family_name: MT Extra
+    type: Regular
+    full_name: MT Extra
+    post_script_name: MT-Extra
+    version: 4.30 (January 2001)
+    description: MT Extra is supplied with MathType and Equation Editor, software
+      applications for the editing of mathematical notation.  It supplies commonly
+      used math symbols that are not present in the Symbol font.  Visit www.dessci.com
+      for details.
+    copyright: Copyright (c) Design Science, Inc, 1999-2004.
+    font: MTEXTRA.TTF
+- name: Malgun Gothic
+  styles:
+  - family_name: Malgun Gothic
+    type: Bold
+    full_name: Malgun Gothic Bold
+    post_script_name: MalgunGothicBold
+    version: '6.60'
+    description: Malgun Gothic is a Korean font developed by taking advantage of ClearType
+      technology, and it provides excellent reading experience particularly onscreen.
+      Its elements are created based on the typeface of Hunminjeongeum, and streamlined
+      with modern form of characters as well as upright and well-regulated strokes.
+      The font is very legible at small sizes with its moderate open counters, and
+      its even inter-character spacing and visual center line maximize the readability.
+    copyright: "© 2013 Microsoft Corporation. All Rights Reserved."
+    font: malgunbd.ttf
+  - family_name: Malgun Gothic
+    type: Regular
+    full_name: Malgun Gothic
+    post_script_name: MalgunGothicRegular
+    version: '6.60'
+    description: Malgun Gothic is a Korean font developed by taking advantage of ClearType
+      technology, and it provides excellent reading experience particularly onscreen.
+      Its elements are created based on the typeface of Hunminjeongeum, and streamlined
+      with modern form of characters as well as upright and well-regulated strokes.
+      The font is very legible at small sizes with its moderate open counters, and
+      its even inter-character spacing and visual center line maximize the readability.
+    copyright: "© 2014 Microsoft Corporation. All Rights Reserved."
+    font: malgun.ttf
+- name: Malgun Gothic Semilight
+  styles:
+  - family_name: Malgun Gothic Semilight
+    type: Regular
+    preferred_family_name: Malgun Gothic
+    preferred_type: Semilight
+    full_name: Malgun Gothic Semilight
+    post_script_name: MalgunGothic-Semilight
+    version: '1.00'
+    description: Malgun Gothic is a Korean font developed by taking advantage of ClearType
+      technology, and it provides excellent reading experience particularly onscreen.
+      Its elements are created based on the typeface of Hunminjeongeum, and streamlined
+      with modern form of characters as well as upright and well-regulated strokes.
+      The font is very legible at small sizes with its moderate open counters, and
+      its even inter-character spacing and visual center line maximize the readability.
+    copyright: "© 2014 Microsoft Corporation. All Rights Reserved."
+    font: malgunsl.ttf
+- name: Marlett
+  styles:
+  - family_name: Marlett
+    type: Regular
+    full_name: Marlett
+    post_script_name: Marlett
+    version: '1.11'
+    copyright: "© 2005 Microsoft Corporation. All Rights Reserved."
+    font: Marlett.ttf
+- name: Matura MT Script Capitals
+  styles:
+  - family_name: Matura MT Script Capitals
+    type: Regular
+    full_name: Matura MT Script Capitals
+    post_script_name: MaturaMTScriptCapitals
+    version: '1.51'
+    copyright: Copyright © The Monotype Corporation plc. 1992. All Rights Reserved.
+    font: MaturaMTScriptCapitals.ttf
+- name: Meiryo
+  styles:
+  - family_name: Meiryo
+    type: Bold
+    full_name: Meiryo Bold
+    post_script_name: Meiryo-Bold
+    version: 6.12i
+    description: Meiryo is a very versatile modern sans serif type designed to give
+      an exceptionally clean appearance on screen, as well as in print. It is optimized
+      for on-screen reading. The letterforms are generously open and well-proportioned;
+      legible and clear at smaller sizes, and dynamic at larger display sizes. The
+      beauty of this face is that it sets text lines in Japanese with Roman seamlessly
+      and harmoniously. The balanced inter-letter spacing enhances horizontal alignment,
+      facilitating smooth reading flow. Meiryo has a very large character set with
+      Japanese and Roman combined, fully scalable outline technology, making it extremely
+      functional for all aspects of communication and publishing. It is a robust legible
+      typeface yet compact enough to enable tight inter-line spacing which is good
+      for space economy.
+    copyright: "© 2012 Microsoft Corporation. All Rights Reserved."
+    font: MeiryoBold.ttf
+  - family_name: Meiryo
+    type: Bold Italic
+    full_name: Meiryo Bold Italic
+    post_script_name: Meiryo-BoldItalic
+    version: 6.12i
+    description: Meiryo is a very versatile modern sans serif type designed to give
+      an exceptionally clean appearance on screen, as well as in print. It is optimized
+      for on-screen reading. The letterforms are generously open and well-proportioned;
+      legible and clear at smaller sizes, and dynamic at larger display sizes. The
+      beauty of this face is that it sets text lines in Japanese with Roman seamlessly
+      and harmoniously. The balanced inter-letter spacing enhances horizontal alignment,
+      facilitating smooth reading flow. Meiryo has a very large character set with
+      Japanese and Roman combined, fully scalable outline technology, making it extremely
+      functional for all aspects of communication and publishing. It is a robust legible
+      typeface yet compact enough to enable tight inter-line spacing which is good
+      for space economy.
+    copyright: "© 2012 Microsoft Corporation. All Rights Reserved."
+    font: MeiryoBoldItalic.ttf
+  - family_name: Meiryo
+    type: Italic
+    full_name: Meiryo Italic
+    post_script_name: Meiryo-Italic
+    version: 6.12i
+    description: Meiryo is a very versatile modern sans serif type designed to give
+      an exceptionally clean appearance on screen, as well as in print. It is optimized
+      for on-screen reading. The letterforms are generously open and well-proportioned;
+      legible and clear at smaller sizes, and dynamic at larger display sizes. The
+      beauty of this face is that it sets text lines in Japanese with Roman seamlessly
+      and harmoniously. The balanced inter-letter spacing enhances horizontal alignment,
+      facilitating smooth reading flow. Meiryo has a very large character set with
+      Japanese and Roman combined, fully scalable outline technology, making it extremely
+      functional for all aspects of communication and publishing. It is a robust legible
+      typeface yet compact enough to enable tight inter-line spacing which is good
+      for space economy.
+    copyright: "© 2012 Microsoft Corporation. All Rights Reserved."
+    font: MeiryoItalic.ttf
+  - family_name: Meiryo
+    type: Regular
+    full_name: Meiryo
+    post_script_name: Meiryo
+    version: 6.12i
+    description: Meiryo is a very versatile modern sans serif type designed to give
+      an exceptionally clean appearance on screen, as well as in print. It is optimized
+      for on-screen reading. The letterforms are generously open and well-proportioned;
+      legible and clear at smaller sizes, and dynamic at larger display sizes. The
+      beauty of this face is that it sets text lines in Japanese with Roman seamlessly
+      and harmoniously. The balanced inter-letter spacing enhances horizontal alignment,
+      facilitating smooth reading flow. Meiryo has a very large character set with
+      Japanese and Roman combined, fully scalable outline technology, making it extremely
+      functional for all aspects of communication and publishing. It is a robust legible
+      typeface yet compact enough to enable tight inter-line spacing which is good
+      for space economy.
+    copyright: "© 2012 Microsoft Corporation. All Rights Reserved."
+    font: Meiryo.ttf
+- name: Microsoft Himalaya
+  styles:
+  - family_name: Microsoft Himalaya
+    type: Regular
+    full_name: Microsoft Himalaya
+    post_script_name: MicrosoftHimalaya
+    version: 5.06i
+    description: The font glyphs compliant with China standard GB18030-2000 with the
+      font name Founder Zang Baiti.
+    copyright: "© 2012  Microsoft Corporation. All Rights Reserved. Portions © 2012
+      Beijing Founder Electronics Co. Ltd. All Rights Reserved."
+    font: himalaya.ttf
+- name: Microsoft JhengHei
+  styles:
+  - family_name: Microsoft JhengHei
+    type: Bold
+    full_name: Microsoft JhengHei Bold
+    post_script_name: MicrosoftJhengHeiBold
+    version: 6.10i
+    copyright: "© 2012 Microsoft Corporation. All rights reserved."
+    font: MSJHBD.ttf
+  - family_name: Microsoft JhengHei
+    type: Regular
+    full_name: Microsoft JhengHei
+    post_script_name: MicrosoftJhengHeiRegular
+    version: 6.10i
+    copyright: "© 2012 Microsoft Corporation. All rights reserved."
+    font: MSJH.ttf
+- name: Microsoft New Tai Lue
+  styles:
+  - family_name: Microsoft New Tai Lue
+    type: Bold
+    full_name: Microsoft New Tai Lue Bold
+    post_script_name: MicrosoftNewTaiLue-Bold
+    version: '5.96'
+    description: The font glyphs are certified compliant with China standard ISO/IEC
+      10646:2003 (GB13000) with the font name DF NewTaiLue Two by DynaComware.
+    copyright: "© 2009 Microsoft Corporation. All Rights Reserved. Portions © 2009
+      DynaComware Corp. All Rights Reserved. Portions © 2008 Ascender Corp. All Rights
+      Reserved."
+    font: ntailub.ttf
+  - family_name: Microsoft New Tai Lue
+    type: Regular
+    full_name: Microsoft New Tai Lue
+    post_script_name: MicrosoftNewTaiLue
+    version: '5.96'
+    description: The font glyphs are certified compliant with China standard ISO/IEC
+      10646:2003 (GB13000) with the font name DF NewTaiLue Two by DynaComware.
+    copyright: "© 2009 Microsoft Corporation. All Rights Reserved. Portions © 2009
+      DynaComware Corp. All Rights Reserved. Portions © 2008 Ascender Corp. All Rights
+      Reserved."
+    font: ntailu.ttf
+- name: Microsoft Tai Le
+  styles:
+  - family_name: Microsoft Tai Le
+    type: Bold
+    full_name: Microsoft Tai Le Bold
+    post_script_name: MicrosoftTaiLe-Bold
+    version: '5.90'
+    description: The Tai Le portions of this font were created by the design teams
+      of Ascender and DynaComware.
+    copyright: "© 2009 Microsoft Corporation. All Rights Reserved. Portions © 2009
+      DynaComware Corp. All Rights Reserved. Portions © 2009 Ascender Corp. All Rights
+      Reserved."
+    font: TaiLeb.ttf
+  - family_name: Microsoft Tai Le
+    type: Regular
+    full_name: Microsoft Tai Le
+    post_script_name: MicrosoftTaiLe
+    version: '5.90'
+    description: The Tai Le portions of this font were created by the design teams
+      of Ascender and DynaComware.
+    copyright: "© 2009 Microsoft Corporation. All Rights Reserved. Portions © 2009
+      DynaComware Corp. All Rights Reserved. Portions © 2009 Ascender Corp. All Rights
+      Reserved."
+    font: taile.ttf
+- name: Microsoft YaHei
+  styles:
+  - family_name: Microsoft YaHei
+    type: Bold
+    full_name: Microsoft YaHei Bold
+    post_script_name: MicrosoftYaHei-Bold
+    version: 6.11i
+    description: The font glyphs are certified compliant with China standard GB18030-2000
+      with the font name Founder Lan Ting Hei.  Microsoft Licensed the font glyph
+      from Beijing Founder  Electronics Co. Ltd.
+    copyright: "© 2008  Microsoft Corporation. All Rights Reserved. Portions © 2008
+      Beijing Founder Electronics Co. Ltd. All Rights Reserved."
+    font: msyhbd.ttf
+  - family_name: Microsoft YaHei
+    type: Regular
+    full_name: Microsoft YaHei
+    post_script_name: MicrosoftYaHei
+    version: 6.10i
+    description: The font glyphs are certified compliant with China standard GB18030-2000
+      with the font name Founder Lan Ting Hei.  Microsoft Licensed the font glyph
+      from Beijing Founder  Electronics Co. Ltd.
+    copyright: "© 2008  Microsoft Corporation. All Rights Reserved. Portions © 2008
+      Beijing Founder Electronics Co. Ltd. All Rights Reserved."
+    font: msyh.ttf
+- name: Microsoft Yi Baiti
+  styles:
+  - family_name: Microsoft Yi Baiti
+    type: Regular
+    full_name: Microsoft Yi Baiti
+    post_script_name: Microsoft-Yi-Baiti
+    version: 5.97i
+    description: The font glyphs compliant with China standard GB18030-2000 with the
+      font name Founder Yi Baiti.
+    copyright: "© 2008  Microsoft Corporation. All Rights Reserved. Portions © 2008
+      Beijing Founder  Electronics Co. Ltd. All Rights Reserved."
+    font: msyi.ttf
+- name: Mistral
+  styles:
+  - family_name: Mistral
+    type: Regular
+    full_name: Mistral
+    post_script_name: Mistral
+    version: '2.10'
+    copyright: "© Copyright by URW, 1992. Portions © 1992 Microsoft Corp. All rights
+      reserved."
+    font: Mistral.ttf
+- name: Modern No. 20
+  styles:
+  - family_name: Modern No. 20
+    type: Regular
+    full_name: Modern No. 20
+    post_script_name: Modern-Regular
+    version: '1.51'
+    copyright: Data by Anna Wheeler and Type Solutions, Inc. © 1993. Microsoft Corporation.
+      All rights reserved.
+    font: ModernNo.20.ttf
+- name: Mongolian Baiti
+  styles:
+  - family_name: Mongolian Baiti
+    type: Regular
+    full_name: Mongolian Baiti
+    post_script_name: MongolianBaiti
+    version: 5.10i
+    description: The font glyphs compliant with China standard GB18030-2000 with the
+      font name Founder Meng Baiti.
+    copyright: "© 2012  Microsoft Corporation. All Rights Reserved. Portions © 2012
+      Beijing Founder  Electronics Co. Ltd. All Rights Reserved."
+    font: monbaiti.ttf
+- name: Monotype Corsiva
+  styles:
+  - family_name: Monotype Corsiva
+    type: Regular
+    full_name: Monotype Corsiva
+    post_script_name: MonotypeCorsiva
+    version: '2.35'
+    description: An italic typeface made in the style of the early Italian cursives,
+      as exemplified by the work of the writing master Ludovico degli Arrighi in the
+      sixteenth century. The capitals are of swash design, with characteristic flourishes,
+      designed primarily for use as initial letters. Corsiva can be used for short
+      text passages in advertising but is best used to add sparkle to invitations,
+      greeting cards and menus, and to give a sense of occasion to certificates and
+      awards.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Monotype Corsiva™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: MonotypeCorsiva.ttf
+- name: Monotype Sorts
+  styles:
+  - family_name: Monotype Sorts
+    type: Regular
+    full_name: Monotype Sorts
+    post_script_name: MonotypeSorts
+    version: '1.50'
+    copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
+      plc/Type Solutions Inc. 1990/91 All Rights Reserved.
+    font: MonotypeSorts.ttf
+- name: News Gothic MT
+  styles:
+  - family_name: News Gothic MT
+    type: Bold
+    full_name: News Gothic MT Bold
+    post_script_name: NewsGothicMT-Bold
+    version: '2.01'
+    copyright: Digitized data copyright (C) 1992-1997 Monotype Typography, Inc. All
+      rights reserved. Monotype News Gothic™ is a trademark of Monotype Typography,
+      Inc. which may be registered in certain jurisdictions.
+    font: News Gothic MT Bold.ttf
+  - family_name: News Gothic MT
+    type: Bold Italic
+    full_name: News Gothic MT Bold Italic
+    post_script_name: NewsGothicMT-BoldItalic
+    version: '2.01'
+    copyright: Digitized data copyright (C) 1992-1997 Monotype Typography, Inc. All
+      rights reserved. Monotype News Gothic™ is a trademark of Monotype Typography,
+      Inc. which may be registered in certain jurisdictions.
+    font: News Gothic MT Bold Italic.ttf
+  - family_name: News Gothic MT
+    type: Italic
+    full_name: News Gothic MT Italic
+    post_script_name: NewsGothicMT-Italic
+    version: '2.01'
+    copyright: Digitized data copyright (C) 1992-1997 Monotype Typography, Inc. All
+      rights reserved. Monotype News Gothic™ is a trademark of Monotype Typography,
+      Inc. which may be registered in certain jurisdictions.
+    font: News Gothic MT Italic.ttf
+  - family_name: News Gothic MT
+    type: Regular
+    full_name: News Gothic MT
+    post_script_name: NewsGothicMT
+    version: '2.01'
+    copyright: Digitized data copyright (C) 1992-1997 Monotype Typography, Inc. All
+      rights reserved. Monotype News Gothic™ is a trademark of Monotype Typography,
+      Inc. which may be registered in certain jurisdictions.
+    font: News Gothic MT.ttf
+- name: Onyx
+  styles:
+  - family_name: Onyx
+    type: Regular
+    full_name: Onyx
+    post_script_name: Onyx
+    version: '1.51'
+    copyright: Typeface © of The Monotype Corporation plc Data © of The Monotype Corporation
+      plc/Type Solutions, Inc. 1990-1991 All Rights Reserved. Portions © 1992 Microsoft
+      Corp. All rights reserved.
+    font: Onyx.ttf
+- name: Palatino Linotype
+  styles:
+  - family_name: Palatino Linotype
+    type: Bold
+    full_name: Palatino Linotype Bold
+    post_script_name: PalatinoLinotype-Bold
+    version: 5.02i
+    description: Palatino Linotype is the definitive new version of Hermann Zapf’s
+      Palatino, which since its design in 1950 has become one of the world's most
+      widely used typefaces. For this new digital version, Professor Zapf has drawn
+      numerous additional characters to include an extensive range of ligatures, numerals,
+      fractions and support for Cyrillic and both monotonic and polytonic Greek. Special
+      care has been taken to enhance the quality of the letterforms when displayed
+      on the computer screen, ensuring that Palatino Linotype is highly legible whether
+      displayed on the screen or in print. This typeface is ideal for use in extended
+      text settings such as books, periodicals and catalogs.
+    copyright: Copyright 1981-1983, 1989,1993, 1998 Heidelberger Druckmaschinen AG.
+      All rights reserved. The  digitally encoded machine readable outline data for
+      producing the Typefaces licensed are the property of Heidelberger Druckmaschinen
+      AG and/or its subsidiaries, represented by Linotype Library GmbH, Dupont Strasse
+      1, 61352 Bad Homburg Germany. Portions © 1996-1998 Microsoft Corporation. All
+      Rights Reserved.
+    font: palab.ttf
+  - family_name: Palatino Linotype
+    type: Bold Italic
+    full_name: Palatino Linotype Bold Italic
+    post_script_name: PalatinoLinotype-BoldItalic
+    version: 5.02i
+    description: Palatino Linotype is the definitive new version of Hermann Zapf’s
+      Palatino, which since its design in 1950 has become one of the world's most
+      widely used typefaces. For this new digital version, Professor Zapf has drawn
+      numerous additional characters to include an extensive range of ligatures, numerals,
+      fractions and support for Cyrillic and both monotonic and polytonic Greek. Special
+      care has been taken to enhance the quality of the letterforms when displayed
+      on the computer screen, ensuring that Palatino Linotype is highly legible whether
+      displayed on the screen or in print. This typeface is ideal for use in extended
+      text settings such as books, periodicals and catalogs.
+    copyright: Copyright 1981-1983, 1989,1993, 1998 Heidelberger Druckmaschinen AG.
+      All rights reserved. The  digitally encoded machine readable outline data for
+      producing the Typefaces licensed are the property of Heidelberger Druckmaschinen
+      AG and/or its subsidiaries, represented by Linotype Library GmbH, Dupont Strasse
+      1, 61352 Bad Homburg Germany. Portions © 1996-1998 Microsoft Corporation. All
+      Rights Reserved.
+    font: palabi.ttf
+  - family_name: Palatino Linotype
+    type: Italic
+    full_name: Palatino Linotype Italic
+    post_script_name: PalatinoLinotype-Italic
+    version: 5.02i
+    description: Palatino Linotype is the definitive new version of Hermann Zapf’s
+      Palatino, which since its design in 1950 has become one of the world's most
+      widely used typefaces. For this new digital version, Professor Zapf has drawn
+      numerous additional characters to include an extensive range of ligatures, numerals,
+      fractions and support for Cyrillic and both monotonic and polytonic Greek. Special
+      care has been taken to enhance the quality of the letterforms when displayed
+      on the computer screen, ensuring that Palatino Linotype is highly legible whether
+      displayed on the screen or in print. This typeface is ideal for use in extended
+      text settings such as books, periodicals and catalogs.
+    copyright: Copyright 1981-1983, 1989,1993, 1998 Heidelberger Druckmaschinen AG.
+      All rights reserved. The  digitally encoded machine readable outline data for
+      producing the Typefaces licensed are the property of Heidelberger Druckmaschinen
+      AG and/or its subsidiaries, represented by Linotype Library GmbH, Dupont Strasse
+      1, 61352 Bad Homburg Germany. Portions © 1996-1998 Microsoft Corporation. All
+      Rights Reserved.
+    font: palai.ttf
+  - family_name: Palatino Linotype
+    type: Regular
+    full_name: Palatino Linotype
+    post_script_name: PalatinoLinotype-Roman
+    version: 5.02i
+    description: Palatino Linotype is the definitive new version of Hermann Zapf’s
+      Palatino, which since its design in 1950 has become one of the world's most
+      widely used typefaces. For this new digital version, Professor Zapf has drawn
+      numerous additional characters to include an extensive range of ligatures, numerals,
+      fractions and support for Cyrillic and both monotonic and polytonic Greek. Special
+      care has been taken to enhance the quality of the letterforms when displayed
+      on the computer screen, ensuring that Palatino Linotype is highly legible whether
+      displayed on the screen or in print. This typeface is ideal for use in extended
+      text settings such as books, periodicals and catalogs.
+    copyright: Copyright 1981-1983, 1989,1993, 1998 Heidelberger Druckmaschinen AG.
+      All rights reserved. The  digitally encoded machine readable outline data for
+      producing the Typefaces licensed are the property of Heidelberger Druckmaschinen
+      AG and/or its subsidiaries, represented by Linotype Library GmbH, Dupont Strasse
+      1, 61352 Bad Homburg Germany. Portions © 1996-1998 Microsoft Corporation. All
+      Rights Reserved.
+    font: pala.ttf
+- name: Perpetua
+  styles:
+  - family_name: Perpetua
+    type: Bold
+    full_name: Perpetua Bold
+    post_script_name: Perpetua-Bold
+    version: '1.76'
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Perpetua® is a trademark of The Monotype Corporation which may be
+      registered in certain jurisdictions.
+    font: Perpetua Bold.ttf
+  - family_name: Perpetua
+    type: Bold Italic
+    full_name: Perpetua Bold Italic
+    post_script_name: Perpetua-BoldItalic
+    version: '1.76'
+    description: A sensitive adaptation of a style of letter that had been popularized
+      for monumental work in stone by Eric Gill. Large scale drawings by Gill were
+      given to Charles Malin, a Parisian punch-cutter, and his hand cut punches were
+      the basis for the font issued by Monotype. The incised quality of Perpetua will
+      lend distinction to any work compatible with its serenity. First used in a private
+      translation called 'The Passion of Perpetua and Felicity'; the italic was originally
+      called Felicity. Widely used as a text face in quality books, Perpetua is also
+      very popular in advertising and display work.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Perpetua® is a trademark of The Monotype Corporation which may be
+      registered in certain jurisdictions.
+    font: Perpetua Bold Italic.ttf
+  - family_name: Perpetua
+    type: Italic
+    full_name: Perpetua Italic
+    post_script_name: Perpetua-Italic
+    version: '1.76'
+    description: A sensitive adaptation of a style of letter that had been popularized
+      for monumental work in stone by Eric Gill. Large scale drawings by Gill were
+      given to Charles Malin, a Parisian punch-cutter, and his hand cut punches were
+      the basis for the font issued by Monotype. The incised quality of Perpetua will
+      lend distinction to any work compatible with its serenity. First used in a private
+      translation called 'The Passion of Perpetua and Felicity'; the italic was originally
+      called Felicity. Widely used as a text face in quality books, Perpetua is also
+      very popular in advertising and display work.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Perpetua® is a trademark of The Monotype Corporation which may be
+      registered in certain jurisdictions.
+    font: Perpetua Italic.ttf
+  - family_name: Perpetua
+    type: Regular
+    full_name: Perpetua
+    post_script_name: Perpetua
+    version: '1.76'
+    description: A sensitive adaptation of a style of letter that had been popularized
+      for monumental work in stone by Eric Gill. Large scale drawings by Gill were
+      given to Charles Malin, a Parisian punch-cutter, and his hand cut punches were
+      the basis for the font issued by Monotype. The incised quality of Perpetua will
+      lend distinction to any work compatible with its serenity. First used in a private
+      translation called 'The Passion of Perpetua and Felicity'; the italic was originally
+      called Felicity. Widely used as a text face in quality books, Perpetua is also
+      very popular in advertising and display work.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Perpetua® is a trademark of The Monotype Corporation which may be
+      registered in certain jurisdictions.
+    font: Perpetua.ttf
+- name: Perpetua Titling MT
+  styles:
+  - family_name: Perpetua Titling MT
+    type: Bold
+    full_name: Perpetua Titling MT Bold
+    post_script_name: PerpetuaTitlingMT-Bold
+    version: '1.76'
+    description: A sensitive adaptation of a style of letter that had been popularized
+      for monumental work in stone by Eric Gill. Large scale drawings by Gill were
+      given to Charles Malin, a Parisian punch-cutter, and his hand cut punches were
+      the basis for the font issued by Monotype. The incised quality of Perpetua will
+      lend distinction to any work compatible with its serenity. First used in a private
+      translation called 'The Passion of Perpetua and Felicity'; the italic was originally
+      called Felicity. Widely used as a text face in quality books, Perpetua is also
+      very popular in advertising and display work.
+    copyright: Design and data by The Monotype Corporation. © 1993. Microsoft Corporation.
+      All rights reserved.
+    font: Perpetua Titling MT Bold.ttf
+  - family_name: Perpetua Titling MT
+    type: Light
+    full_name: Perpetua Titling MT Light
+    post_script_name: PerpetuaTitlingMT-Light
+    version: '1.76'
+    description: A sensitive adaptation of a style of letter that had been popularized
+      for monumental work in stone by Eric Gill. Large scale drawings by Gill were
+      given to Charles Malin, a Parisian punch-cutter, and his hand cut punches were
+      the basis for the font issued by Monotype. The incised quality of Perpetua will
+      lend distinction to any work compatible with its serenity. First used in a private
+      translation called 'The Passion of Perpetua and Felicity'; the italic was originally
+      called Felicity. Widely used as a text face in quality books, Perpetua is also
+      very popular in advertising and display work.
+    copyright: Design and data by The Monotype Corporation. © 1993. Microsoft Corporation.
+      All rights reserved.
+    font: Perpetua Titling MT.ttf
+- name: Rockwell
+  styles:
+  - family_name: Rockwell
+    type: Bold
+    full_name: Rockwell Bold
+    post_script_name: Rockwell-Bold
+    version: '1.65'
+    description: Rockwell is a distinctive version of a geometric slab serif design,
+      which has retained its popularity since its appearance in the 1930's. The slab
+      serifs, or Egyptians, originated in the nineteenth century when they were used
+      principally for display work. Rockwell is notable for its judiciously clipped
+      slab serifs, and is given a particular sparkle by means of its angular terminals.
+      In more recent years this style of typeface has been increasingly used for text
+      setting where their even colour and visual impact can be fully exploited.
+    copyright: Digitized data copyright (C) 1992 - 1997 The Monotype Corporation.
+      Rockwell® is a trademark of The Monotype Corporation which may be registered
+      in certain jurisdictions. Portions copyright Microsoft corporation.  All rights
+      reserved.
+    font: Rockwell Bold.ttf
+  - family_name: Rockwell
+    type: Bold Italic
+    full_name: Rockwell Bold Italic
+    post_script_name: Rockwell-BoldItalic
+    version: '1.65'
+    description: Rockwell is a distinctive version of a geometric slab serif design,
+      which has retained its popularity since its appearance in the 1930's. The slab
+      serifs, or Egyptians, originated in the nineteenth century when they were used
+      principally for display work. Rockwell is notable for its judiciously clipped
+      slab serifs, and is given a particular sparkle by means of its angular terminals.
+      In more recent years this style of typeface has been increasingly used for text
+      setting where their even colour and visual impact can be fully exploited.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Rockwell® is a trademark of The Monotype Corporation which may be
+      registered in certain jurisdictions.
+    font: Rockwell Bold Italic.ttf
+  - family_name: Rockwell
+    type: Italic
+    full_name: Rockwell Italic
+    post_script_name: Rockwell-Italic
+    version: '1.65'
+    description: Rockwell is a distinctive version of a geometric slab serif design,
+      which has retained its popularity since its appearance in the 1930's. The slab
+      serifs, or Egyptians, originated in the nineteenth century when they were used
+      principally for display work. Rockwell is notable for its judiciously clipped
+      slab serifs, and is given a particular sparkle by means of its angular terminals.
+      In more recent years this style of typeface has been increasingly used for text
+      setting where their even colour and visual impact can be fully exploited.
+    copyright: Digitized data copyright (C) 1992 - 1997 The Monotype Corporation.
+      Portions copyright Microsoft corporation.  All rights reserved.
+    font: Rockwell Italic.ttf
+  - family_name: Rockwell
+    type: Regular
+    full_name: Rockwell
+    post_script_name: Rockwell
+    version: '1.65'
+    description: Rockwell is a distinctive version of a geometric slab serif design,
+      which has retained its popularity since its appearance in the 1930's. The slab
+      serifs, or Egyptians, originated in the nineteenth century when they were used
+      principally for display work. Rockwell is notable for its judiciously clipped
+      slab serifs, and is given a particular sparkle by means of its angular terminals.
+      In more recent years this style of typeface has been increasingly used for text
+      setting where their even colour and visual impact can be fully exploited.
+    copyright: Digitized data copyright (C) 1992 - 1997 The Monotype Corporation.  Rockwell®
+      is a trademark of The Monotype Corporation which may be registered in certain
+      jurisdictions. Portions copyright Microsoft  Corporation.  All rights reserved.
+    font: Rockwell.ttf
+- name: Rockwell Condensed
+  styles:
+  - family_name: Rockwell Condensed
+    type: Bold
+    full_name: Rockwell Condensed Bold
+    post_script_name: Rockwell-CondensedBold
+    version: '1.65'
+    description: Rockwell is a distinctive version of a geometric slab serif design,
+      which has retained its popularity since its appearance in the 1930's. The slab
+      serifs, or Egyptians, originated in the nineteenth century when they were used
+      principally for display work. Rockwell is notable for its judiciously clipped
+      slab serifs, and is given a particular sparkle by means of its angular terminals.
+      In more recent years this style of typeface has been increasingly used for text
+      setting where their even colour and visual impact can be fully exploited.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1995. All rights
+      reserved. Rockwell® is a trademark of The Monotype Corporation which may be
+      registered in certain jurisdictions.
+    font: Rockwell Condensed Bold.ttf
+  - family_name: Rockwell Condensed
+    type: Regular
+    full_name: Rockwell Condensed
+    post_script_name: Rockwell-Condensed
+    version: '1.65'
+    description: Rockwell is a distinctive version of a geometric slab serif design,
+      which has retained its popularity since its appearance in the 1930's. The slab
+      serifs, or Egyptians, originated in the nineteenth century when they were used
+      principally for display work. Rockwell is notable for its judiciously clipped
+      slab serifs, and is given a particular sparkle by means of its angular terminals.
+      In more recent years this style of typeface has been increasingly used for text
+      setting where their even colour and visual impact can be fully exploited.
+    copyright: Digitized data copyright (C) 1992 - 1996 The Monotype Corporation.
+      All rights reserved. Rockwell® is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Rockwell Condensed.ttf
+- name: Rockwell Extra Bold
+  styles:
+  - family_name: Rockwell Extra Bold
+    type: Regular
+    full_name: Rockwell Extra Bold
+    post_script_name: Rockwell-ExtraBold
+    version: '1.65'
+    description: Rockwell is a distinctive version of a geometric slab serif design,
+      which has retained its popularity since its appearance in the 1930's. The slab
+      serifs, or Egyptians, originated in the nineteenth century when they were used
+      principally for display work. Rockwell is notable for its judiciously clipped
+      slab serifs, and is given a particular sparkle by means of its angular terminals.
+      In more recent years this style of typeface has been increasingly used for text
+      setting where their even colour and visual impact can be fully exploited.
+    copyright: Design and data by The Monotype Corporation. © 1993. Portions copyright
+      Microsoft Corporation.  All rights reserved.
+    font: Rockwell Extra Bold.ttf
+- name: STHupo
+  styles:
+  - family_name: STHupo
+    type: Regular
+    full_name: STHupo
+    post_script_name: STHupo
+    version: '1.02'
+    copyright: Copyright (c) 1991-1998, Changzhou SinoType Technology Co., Ltd.  All
+      rights reserved.
+    font: STHUPO.TTF
+- name: STLiti
+  styles:
+  - family_name: STLiti
+    type: Regular
+    full_name: STLiti
+    post_script_name: STLiti
+    version: '1.02'
+    copyright: Copyright (c) 1991-1998, Changzhou SinoType Technology Co., Ltd.  All
+      rights reserved.
+    font: STLITI.ttf
+- name: STXingkai
+  styles:
+  - family_name: STXingkai
+    type: Regular
+    full_name: STXingkai
+    post_script_name: STXingkai
+    version: '1.02'
+    copyright: Copyright (c) 1991-1998, Changzhou SinoType Technology Co., Ltd.  All
+      rights reserved.
+    font: STXINGKA.ttf
+- name: STXinwei
+  styles:
+  - family_name: STXinwei
+    type: Regular
+    full_name: STXinwei
+    post_script_name: STXinwei
+    version: '1.02'
+    copyright: Copyright (c) 1991-1998, Changzhou SinoType Technology Co., Ltd.  All
+      rights reserved.
+    font: STXINWEI.ttf
+- name: STZhongsong
+  styles:
+  - family_name: STZhongsong
+    type: Regular
+    full_name: STZhongsong
+    post_script_name: STZhongsong
+    version: '1.02'
+    copyright: Copyright (c) 1991-1998, Changzhou SinoType Technology Co., Ltd.  All
+      rights reserved.
+    font: STZHONGS.ttf
+- name: Segoe Print
+  styles:
+  - family_name: Segoe Print
+    type: Bold
+    full_name: Segoe Print Bold
+    post_script_name: SegoePrint-Bold
+    version: '5.02'
+    copyright: "© 2009 Microsoft Corporation. All Rights Reserved."
+    font: Segoe Print Bold.ttf
+- name: Segoe Script
+  styles:
+  - family_name: Segoe Script
+    type: Bold
+    full_name: Segoe Script Bold
+    post_script_name: SegoeScript-Bold
+    version: '5.00'
+    copyright: C 2006 Microsoft Corporation. All Rights Reserved.
+    font: Segoe Script Bold.ttf
+- name: SimHei
+  styles:
+  - family_name: SimHei
+    type: Regular
+    full_name: SimHei
+    post_script_name: SimHei
+    version: 5.03i
+    copyright: "© Beijing ZhongYi Electronics Co., 1995-2005, All rights reserved"
+    font: SimHei.ttf
+- name: SimSun
+  styles:
+  - family_name: SimSun
+    type: Regular
+    full_name: SimSun
+    post_script_name: SimSun
+    version: 5.04i
+    copyright: "© Copyright ZHONGYI Electronic Co. 2001"
+    font: SimSun.ttf
+- name: SimSun-ExtB
+  styles:
+  - family_name: SimSun-ExtB
+    type: Regular
+    full_name: SimSun-ExtB
+    post_script_name: SimSun-ExtB
+    version: 5.01i
+    copyright: "© Beijing ZhongYi Electronics Co., 1995-2003, All rights reserved.
+      \ Portions © 2011 The Monotype Corporation."
+    font: simsunb.ttf
+- name: Stencil
+  styles:
+  - family_name: Stencil
+    type: Regular
+    full_name: Stencil
+    post_script_name: Stencil
+    version: '1.52'
+    description: Stencil faces have been made for as long as people have been shipping
+      wooden boxes. Most of the letterforms look a bit like a softer, bolder Clarendon
+      before lines are cut through it to allow counters (those little spaces enclosed
+      in 'a', 'b' and other letters) to remain as counters without becoming solid
+      blobs. Consider this Stencil face a decorative font for limited use; a little
+      goes a long way.
+    copyright: Data © 1992 URW. Portions © 1992 Microsoft Corp. All rights reserved.
+    font: Stencil.ttf
+- name: Tahoma
+  styles:
+  - family_name: Tahoma
+    type: Bold
+    full_name: Tahoma Bold
+    post_script_name: Tahoma-Bold
+    version: 5.25i
+    copyright: "© 2012 Microsoft Corporation. All rights reserved."
+    font: tahomabd.ttf
+  - family_name: Tahoma
+    type: Regular
+    full_name: Tahoma
+    post_script_name: Tahoma
+    version: 5.25i
+    copyright: "© 2012 Microsoft Corporation. All rights reserved."
+    font: tahoma.ttf
+- name: Trebuchet MS
+  styles:
+  - family_name: Trebuchet MS
+    type: Bold Italic
+    full_name: Trebuchet MS Bold Italic
+    post_script_name: Trebuchet-BoldItalic
+    version: '1.26'
+    description: Trebuchet, designed by Vincent Connare in 1996, is a humanist sans
+      serif designed for easy screen readability. Trebuchet takes its inspiration
+      from the sans serifs of the 1930s which had large x heights and round features
+      intended to promote readability on signs. The typeface name is credited to a
+      puzzle heard at Microsoft, where the question was asked, "could you build a
+      Trebuchet (a form of medieval catapult) to launch a person from the main campus
+      to the consumer campus, and how?" The Trebuchet fonts are intended to be the
+      vehicle that fires your messages across the Internet. "Launch your message with
+      a Trebuchet page".
+    copyright: Copyright (c) 1996 Microsoft Corporation. All rights reserved.
+    font: TrebuchetMSBoldItalic.ttf
+- name: Tw Cen MT
+  styles:
+  - family_name: Tw Cen MT
+    type: Bold
+    full_name: Tw Cen MT Bold
+    post_script_name: TwCenMT-Bold
+    version: '1.02'
+    description: 20th Century was designed and drawn by Sol Hess in the Lanston Monotype
+      drawing office between 1936 and 1947. The first weights were added to the Monotype
+      typeface library in 1959. This is a face based on geometric shapes which originated
+      in Germany in the early 1920's and became an integral part of the Bauhaus movement
+      of that time. Form and function became the key words, unnecessary decoration
+      was scorned. This clean cut, sans serif with geometric shapes was most appropriate.
+      The lighter weights can be used for text setting, the bold and condensed fonts
+      are suitable for display in headlines and advertising.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1997. All rights
+      reserved. Twentieth Century™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Tw Cen MT Bold.ttf
+  - family_name: Tw Cen MT
+    type: Bold Italic
+    full_name: Tw Cen MT Bold Italic
+    post_script_name: TwCenMT-BoldItalic
+    version: '1.02'
+    description: 20th Century was designed and drawn by Sol Hess in the Lanston Monotype
+      drawing office between 1936 and 1947. The first weights were added to the Monotype
+      typeface library in 1959. This is a face based on geometric shapes which originated
+      in Germany in the early 1920's and became an integral part of the Bauhaus movement
+      of that time. Form and function became the key words, unnecessary decoration
+      was scorned. This clean cut, sans serif with geometric shapes was most appropriate.
+      The lighter weights can be used for text setting, the bold and condensed fonts
+      are suitable for display in headlines and advertising.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1997. All rights
+      reserved. Twentieth Century™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Tw Cen MT Bold Italic.ttf
+  - family_name: Tw Cen MT
+    type: Italic
+    full_name: Tw Cen MT Italic
+    post_script_name: TwCenMT-Italic
+    version: '1.02'
+    description: 20th Century was designed and drawn by Sol Hess in the Lanston Monotype
+      drawing office between 1936 and 1947. The first weights were added to the Monotype
+      typeface library in 1959. This is a face based on geometric shapes which originated
+      in Germany in the early 1920's and became an integral part of the Bauhaus movement
+      of that time. Form and function became the key words, unnecessary decoration
+      was scorned. This clean cut, sans serif with geometric shapes was most appropriate.
+      The lighter weights can be used for text setting, the bold and condensed fonts
+      are suitable for display in headlines and advertising.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1997. All rights
+      reserved. Twentieth Century™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Tw Cen MT Italic.ttf
+  - family_name: Tw Cen MT
+    type: Regular
+    full_name: Tw Cen MT
+    post_script_name: TwCenMT-Regular
+    version: '1.02'
+    description: 20th Century was designed and drawn by Sol Hess in the Lanston Monotype
+      drawing office between 1936 and 1947. The first weights were added to the Monotype
+      typeface library in 1959. This is a face based on geometric shapes which originated
+      in Germany in the early 1920's and became an integral part of the Bauhaus movement
+      of that time. Form and function became the key words, unnecessary decoration
+      was scorned. This clean cut, sans serif with geometric shapes was most appropriate.
+      The lighter weights can be used for text setting, the bold and condensed fonts
+      are suitable for display in headlines and advertising.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1997. All rights
+      reserved. Twentieth Century™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Tw Cen MT.ttf
+- name: Tw Cen MT Condensed
+  styles:
+  - family_name: Tw Cen MT Condensed
+    type: Bold
+    full_name: Tw Cen MT Condensed Bold
+    post_script_name: TwCenMT-CondensedBold
+    version: '1.02'
+    description: 20th Century was designed and drawn by Sol Hess in the Lanston Monotype
+      drawing office between 1936 and 1947. The first weights were added to the Monotype
+      typeface library in 1959. This is a face based on geometric shapes which originated
+      in Germany in the early 1920's and became an integral part of the Bauhaus movement
+      of that time. Form and function became the key words, unnecessary decoration
+      was scorned. This clean cut, sans serif with geometric shapes was most appropriate.
+      The lighter weights can be used for text setting, the bold and condensed fonts
+      are suitable for display in headlines and advertising.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1997. All rights
+      reserved. Twentieth Century™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Tw Cen MT Condensed Bold.ttf
+  - family_name: Tw Cen MT Condensed
+    type: Regular
+    full_name: Tw Cen MT Condensed
+    post_script_name: TwCenMT-Condensed
+    version: '1.02'
+    description: 20th Century was designed and drawn by Sol Hess in the Lanston Monotype
+      drawing office between 1936 and 1947. The first weights were added to the Monotype
+      typeface library in 1959. This is a face based on geometric shapes which originated
+      in Germany in the early 1920's and became an integral part of the Bauhaus movement
+      of that time. Form and function became the key words, unnecessary decoration
+      was scorned. This clean cut, sans serif with geometric shapes was most appropriate.
+      The lighter weights can be used for text setting, the bold and condensed fonts
+      are suitable for display in headlines and advertising.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1997. All rights
+      reserved. Twentieth Century™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Tw Cen MT Condensed.ttf
+- name: Tw Cen MT Condensed Extra Bold
+  styles:
+  - family_name: Tw Cen MT Condensed Extra Bold
+    type: Regular
+    full_name: Tw Cen MT Condensed Extra Bold
+    post_script_name: TwCenMT-CondensedExtraBold
+    version: '1.03'
+    description: 20th Century was designed and drawn by Sol Hess in the Lanston Monotype
+      drawing office between 1936 and 1947. The first weights were added to the Monotype
+      typeface library in 1959. This is a face based on geometric shapes which originated
+      in Germany in the early 1920's and became an integral part of the Bauhaus movement
+      of that time. Form and function became the key words, unnecessary decoration
+      was scorned. This clean cut, sans serif with geometric shapes was most appropriate.
+      The lighter weights can be used for text setting, the bold and condensed fonts
+      are suitable for display in headlines and advertising.
+    copyright: Digitized data copyright The Monotype Corporation 1991-1997. All rights
+      reserved. Twentieth Century™ is a trademark of The Monotype Corporation which
+      may be registered in certain jurisdictions.
+    font: Tw Cen MT Condensed Extra Bold.ttf
+- name: Verdana
+  styles:
+  - family_name: Verdana
+    type: Bold
+    full_name: Verdana Bold
+    post_script_name: Verdana-Bold
+    version: '5.02'
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Verdana Bold.ttf
+  - family_name: Verdana
+    type: Bold Italic
+    full_name: Verdana Bold Italic
+    post_script_name: Verdana-BoldItalic
+    version: '5.02'
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Verdana Bold Italic.ttf
+  - family_name: Verdana
+    type: Italic
+    full_name: Verdana Italic
+    post_script_name: Verdana-Italic
+    version: '5.02'
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Verdana Italic.ttf
+  - family_name: Verdana
+    type: Regular
+    full_name: Verdana
+    post_script_name: Verdana
+    version: '5.02'
+    copyright: "© 2008 Microsoft Corporation. All Rights Reserved."
+    font: Verdana.ttf
+- name: Webdings
+  styles:
+  - family_name: Webdings
+    type: Regular
+    full_name: Webdings
+    post_script_name: Webdings
+    version: '5.00'
+    copyright: "© 2006 Microsoft Corporation. All Rights Reserved."
+    font: webdings.ttf
+- name: Wide Latin
+  styles:
+  - family_name: Wide Latin
+    type: Regular
+    full_name: Wide Latin
+    post_script_name: LatinWide
+    version: '1.51'
+    copyright: Typeface © 1992 Stphenson Blake (Holdings) Ltd. Data © 1992 URW. Portions
+      © 1992 Microsoft Corp. All rights reserved.
+    font: WideLatin.ttf
+- name: Wingdings
+  styles:
+  - family_name: Wingdings
+    type: Regular
+    full_name: Wingdings
+    post_script_name: Wingdings-Regular
+    version: '5.03'
+    description: The Wingdings fonts were designed by Kris Holmes and Charles Bigelow
+      in 1990 and 1991.
+    copyright: "© 2006 Microsoft Corporation. All Rights Reserved."
+    font: Wingdings.ttf
+- name: Wingdings 2
+  styles:
+  - family_name: Wingdings 2
+    type: Regular
+    full_name: Wingdings 2
+    post_script_name: Wingdings2
+    version: '5.03'
+    copyright: Wingdings 2 designed by Bigelow & Holmes Inc. for Microsoft Corporation.
+      Copyright © 1992 Microsoft Corporation. Pat. Pend. All Rights Reserved. © 1990-1991
+      Type Solutions, Inc. All Rights Reserved.
+    font: Wingdings 2.ttf
+- name: Wingdings 3
+  styles:
+  - family_name: Wingdings 3
+    type: Regular
+    full_name: Wingdings 3
+    post_script_name: Wingdings3
+    version: '5.03'
+    copyright: Wingdings 3 designed by Bigelow & Holmes Inc. for Microsoft Corporation.
+      Copyright © 1992 Microsoft Corporation. Pat. pend. All Rights Reserved. © 1990-1991
+      Type Solutions, Inc. All Rights Reserved.
+    font: Wingdings 3.ttf
+- name: Yu Gothic
+  styles:
+  - family_name: Yu Gothic
+    type: Bold
+    full_name: Yu Gothic Bold
+    post_script_name: YuGothic-Bold
+    version: 1.60; MAC
+    copyright: Copyright © 2014 JIYUKOBO Ltd. All Rights Reserved.
+    font: YuGothB.ttf
+  - family_name: Yu Gothic
+    type: Regular
+    full_name: Yu Gothic Regular
+    post_script_name: YuGothic-Regular
+    version: '1.60: MAC'
+    copyright: Copyright © 2014 JIYUKOBO Ltd. All Rights Reserved.
+    font: YuGothR.ttf
+- name: Yu Gothic Light
+  styles:
+  - family_name: Yu Gothic Light
+    type: Regular
+    preferred_family_name: Yu Gothic
+    preferred_type: Light
+    full_name: Yu Gothic Light
+    post_script_name: YuGothic-Light
+    version: '1.60: MAC'
+    copyright: Copyright © 2014 JIYUKOBO Ltd. All Rights Reserved.
+    font: YuGothL.ttf
+- name: Yu Gothic Medium
+  styles:
+  - family_name: Yu Gothic Medium
+    type: Regular
+    preferred_family_name: Yu Gothic
+    preferred_type: Medium
+    full_name: Yu Gothic Medium
+    post_script_name: YuGothic-Medium
+    version: 1.00; MAC
+    copyright: Copyright © 2014 JIYUKOBO Ltd. All Rights Reserved.
+    font: YuGothM.ttf
+- name: Yu Mincho
+  styles:
+  - family_name: Yu Mincho
+    type: Regular
+    preferred_family_name: Yu Mincho
+    preferred_type: Regular
+    full_name: Yu Mincho Regular
+    post_script_name: YuMincho-Regular
+    version: '1.65'
+    copyright: Copyright © 2015 JIYUKOBO Ltd. All Rights Reserved.
+    font: yumin.ttf
+extract: {}
+copyright: Design and data by The Monotype Corporation. © 1993. Portions copyright
+  Microsoft Corporation.  All rights reserved.
+license_url: http://www.monotype.com/html/mtname/ms_welcome.html
+requires_license_agreement: |-
+  Office for Mac Privacy Statement
+  MICROSOFT SOFTWARE LICENSE TERMS
+  MICROSOFT OFFICE FOR MAC
+  These license terms are an agreement between Microsoft Corporation (or based on where you live, one of its affiliates) and you. Please read them. They apply to the software named above, which includes the media on which you received it, if any. The terms also apply to any Microsoft
+  •	updates,
+  •	supplements,
+  •	Internet-based services, and
+  •	support services
+  for this software, unless other terms accompany those items. If so, those terms apply.
+  By using the software, you accept these terms. If you do not accept them, do not use the software.
+  As described below, using some features also operates as your consent to the transmission of certain standard computer information for Internet-based services.
+  If you comply with these license terms, you have the perpetual rights below.
+  1.	INSTALLATION AND USE RIGHTS.
+  a.	Installation and Use. You may install and use one copy of the software on your device.
+  b.	Third Party Programs. The software may include third party programs that Microsoft, not the third party, licenses to you under this agreement. Notices, if any, for the third party program are included for your information only.
+  2.	INTERNET-BASED SERVICES. Microsoft provides Internet-based services with the software. It may change or cancel them at any time. You may not use the service to try to gain unauthorized access to any service, data, account or network by any means.
+  3.	SCOPE OF LICENSE. The software is licensed, not sold. This agreement only gives you some rights to use the software. Microsoft reserves all other rights. Unless applicable law gives you more rights despite this limitation, you may use the software only as expressly permitted in this agreement. In doing so, you must comply with any technical limitations in the software that only allow you to use it in certain ways. You may not
+  •	work around any technical limitations in the software;
+  •	reverse engineer, decompile or disassemble the software, except and only to the extent that applicable law expressly permits, despite this limitation;
+  •	make more copies of the software than specified in this agreement or allowed by applicable law, despite this limitation;
+  •	publish the software for others to copy;
+  •	rent, lease or lend the software;
+  •	use the software for commercial software hosting services.
+  4.	BACKUP COPY. You may make one backup copy of the software. You may use it only to reinstall the software.
+  5.	DOCUMENTATION. Any person that has valid access to your computer or internal network may copy and use the documentation for your internal, reference purposes.
+  6.	TRANSFER TO ANOTHER DEVICE. You may uninstall the software and install it on another device for your use. You may not do so to share this license between devices.
+  7.	EXPORT RESTRICTIONS. The software is subject to United States export laws and regulations. You must comply with all domestic and international export laws and regulations that apply to the software. These laws include restrictions on destinations, end users and end use. For additional information, see www.microsoft.com/exporting.
+  8.	SUPPORT SERVICES. Because this software is “as is,” we may not provide support services for it.
+  9.	ENTIRE AGREEMENT. This agreement, and the terms for supplements, updates, Internet-based services and support services that you use, are the entire agreement for the software and support services.
+  10.	APPLICABLE LAW.
+  a.	United States. If you acquired the software in the United States, Washington state law governs the interpretation of this agreement and applies to claims for breach of it, regardless of conflict of laws principles. The laws of the state where you live govern all other claims, including claims under state consumer protection laws, unfair competition laws, and in tort.
+  b.	Outside the United States. If you acquired the software in any other country, the laws of that country apply.
+  11.	LEGAL EFFECT. This agreement describes certain legal rights. You may have other rights under the laws of your country. You may also have rights with respect to the party from whom you acquired the software. This agreement does not change your rights under the laws of your country if the laws of your country do not permit it to do so.
+  12.	DISCLAIMER OF WARRANTY. The software is licensed “as-is.” You bear the risk of using it. Microsoft gives no express warranties, guarantees or conditions. You may have additional consumer rights or statutory guarantees under your local laws which this agreement cannot change. To the extent permitted under your local laws, Microsoft excludes the implied warranties of merchantability, fitness for a particular purpose and non-infringement.
+  FOR AUSTRALIA – You have statutory guarantees under the Australian Consumer Law and nothing in these terms is intended to affect those rights.
+  13.	LIMITATION ON AND EXCLUSION OF REMEDIES AND DAMAGES. You can recover from Microsoft and its suppliers only direct damages up to U.S. $5.00. You cannot recover any other damages, including consequential, lost profits, special, indirect or incidental damages.
+  This limitation applies to
+  •	anything related to the software, services, content (including code) on third party Internet sites, or third party programs; and
+  •	claims for breach of contract, breach of warranty, guarantee or condition, strict liability, negligence, or other tort to the extent permitted by applicable law.
+  It also applies even if Microsoft knew or should have known about the possibility of the damages. The above limitation or exclusion may not apply to you because your country may not allow the exclusion or limitation of incidental, consequential or other damages.
+command: create-formula --name Office\ Preview http://download.microsoft.com/download/8/1/3/8136bf31-4c2e-4b5f-bee9-117ab004ab35/microsoft_excel_15.11.1_updater.pkg


### PR DESCRIPTION
Restores the Office Preview formula.

It was [removed](https://github.com/fontist/formulas/commit/808f79c0af43d9d05be0683060bae4d1fe72dbb3) because it was used to install some often-used font (afaik, Cambria) but it required an upgraded fontist, so it failed at CI. The `v3` formulas branch requires an upgraded fontist, so it's fine now.

More than that, this formula is avoided by default, because fontist avoids formulas larger than 300 MB (unless it's cached), and the office preview formula is 700 MB. At the same time it can be installed with a special flag, like `--size-limit`, or by a formula name:

```
fontist install -F office_preview
```

See https://github.com/fontist/formulas/issues/73