### PR TITLE
Add adobe open source fonts

### DIFF
--- a/Formulas/akabara-cinderella.yml
+++ b/Formulas/akabara-cinderella.yml
@@ -23,7 +23,7 @@ extract: {}
 copyright: Copyright(c) 2017 M+ FONTS PROJECT/MODI
 command: create-formula https://modi.jpn.org/download/MODI_akabara-cinderella_2018_0811.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2017 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/asatte.yml
+++ b/Formulas/asatte.yml
@@ -1,5 +1,6 @@
 ---
 description: ASATTE
+homepage: https://modi.jpn.org/
 resources:
   ASATTE.zip:
     urls:
@@ -22,7 +23,7 @@ extract: {}
 copyright: MODI
 command: create-formula https://modi.jpn.org/download/MODI_asatte_2017_0527.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2017 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/bokutachinogothic.yml
+++ b/Formulas/bokutachinogothic.yml
@@ -1,0 +1,28 @@
+---
+description: BokutachinoGothic
+homepage: https://fontopo.com/
+resources:
+  BokutachinoGothic.zip:
+    urls:
+    - https://fontopo.com/fontdata/boku.zip
+    sha256: ca5b0175468bad6693cbf2efd9ada0ff3e18d77da0d745d61024be9f73392584
+    file_size: 1519804
+fonts:
+- name: BokutachinoGothic
+  styles:
+  - family_name: BokutachinoGothic
+    type: Regular
+    preferred_family_name: BokutachinoGothic
+    preferred_type: Regular
+    full_name: BokutachinoGothic
+    post_script_name: BokutachinoGothic
+    version: '0.10'
+    copyright: fontopo
+    font: bokutachi.otf
+extract: {}
+copyright: fontopo
+command: create-formula https://fontopo.com/fontdata/boku.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/bokutachinogothic2bold.yml
+++ b/Formulas/bokutachinogothic2bold.yml
@@ -1,0 +1,269 @@
+---
+description: BokutachinoGothic2Bold
+homepage: https://fontopo.com/
+resources:
+  BokutachinoGothic2Bold.zip:
+    urls:
+    - https://fontopo.com/fontdata/boku2b.zip
+    sha256: da49234eba987a25a0b530776ebafa6870a5fed9a8b9dc8d1c413ec2bea0bf8b
+    file_size: 1455881
+fonts:
+- name: BokutachinoGothic2Bold
+  styles:
+  - family_name: BokutachinoGothic2Bold
+    type: Regular
+    preferred_family_name: BokutachinoGothic2Bold
+    preferred_type: Regular
+    full_name: BokutachinoGothic2Bold
+    post_script_name: BokutachinoGothic2Bold
+    version: '1.01'
+    copyright: fontopo
+    font: Boku2-Bold.otf
+extract: {}
+copyright: fontopo
+license_url: https://fontopo.com/?page_id=55
+open_license: |-
+  Apache License
+  Version 2.0、2004年1月
+  http://www.apache.org/licenses/
+  使用、複製、および頒布に関する条項
+
+  1. 定義
+
+  「ライセンス」とは、このドキュメントの第1項から第9項までで定義している、使用、複製、および頒布に関する条項を指します。
+
+  「ライセンサー」とは、著作権所有者、あるいは著作権所有者がライセンス付与対象として認めた者を指します。
+
+  「法人」とは、行為者と、行為者を管理するか行為者により管理されるか行為者共通の管理下にある他のすべての者とから成る連合体を指します。この定義における「管理」とは、(i) 契約またはその他により、直接または間接的にこの法人の指揮・経営を行う権限、または (ii) この法人の50%以上の株式の所有権または (iii) 受益所有権を有することを指します。
+
+  「あなた」とは、本ライセンスにより付与される権利を行使する個人または法人を指します。
+
+  「ソース」形式とは、ソフトウェアのソースコード、ドキュメントソース、設定ファイルといった、変更を加えるのに好都合な形式を指します。
+
+  「オブジェクト」形式とは、コンパイルされたオブジェクトコード、生成されたドキュメント、他のメディアへの変換物といった、ソース形式の機械的な変換により生じる形式を指します。
+
+  「成果物」とは、ソース形式であるとオブジェクト形式であるとを問わず、製作物に挿入または添付される（後出の付録に例がある）著作権表示で示された著作物で、本ライセンスに基づいて利用が許されるものを指します。
+
+  「派生成果物」とは、編集上の改訂、注解、推敲など、成果物を基にしていて全体としてオリジナル著作物と呼べるような製作物全般を指します。本ライセンスでは、成果物や派生成果物から分離できる製作物や、成果物や派生成果物のインタフェースへの単なるリンク（または名前によるバインド）を、派生成果物に含めません。
+
+  「コントリビューション」とは、成果物のオリジナルバージョンならびに成果物または派生成果物への変更や追加も含めて、著作権所有者あるいは著作権所有者が認めた個人または法人による成果物への組み込みを意図してライセンサーに提出される著作物全般を指します。この定義における「提出」とは、成果物を論じたり改良するためにライセンサーまたはその代理者により管理される電子的メーリングリスト、ソースコード管理システム、問題追跡システムといった、電子的方法、口頭、または書面で、ライセンサーまたはその代理者に情報を送ることを指します。ただし、著作権所有者が書面で「コントリビューションでない」と明示したものは除きます。
+
+  「コントリビューター」とは、ライセンサーおよびその代理を務める個人または法人で、自分のコントリビューションがライセンサーに受領されて成果物に組み込まれた者を指します。
+
+  2. 著作権ライセンスの付与
+
+  本ライセンスの条項に従って、各コントリビューターはあなたに対し、ソース形式であれオブジェクト形式であれ、成果物および派生成果物を複製したり、派生成果物を作成したり、公に表示したり、公に実行したり、サブライセンスしたり、頒布したりする、無期限で世界規模で非独占的で使用料無料で取り消し不能な著作権ライセンスを付与します。
+
+  3. 特許ライセンスの付与
+
+  本ライセンスの条項に従って、各コントリビューターはあなたに対し、成果物を作成したり、使用したり、販売したり、販売用に提供したり、インポートしたり、その他の方法で移転したりする、無期限で世界規模で非独占的で使用料無料で取り消し不能な（この項で明記したものは除く）特許ライセンスを付与します。ただし、このようなライセンスは、コントリビューターによってライセンス可能な特許申請のうち、当該コントリビューターのコントリビューションを単独または該当する成果物と組み合わせて用いることで必然的に侵害されるものにのみ適用されます。あなたが誰かに対し、交差請求や反訴を含めて、成果物あるいは成果物に組み込まれたコントリビューションが直接または間接的な特許侵害に当たるとして特許訴訟を起こした場合、本ライセンスに基づいてあなたに付与された特許ライセンスは、そうした訴訟が正式に起こされた時点で終了するものとします。
+
+  4. 再頒布
+
+  あなたは、ソース形式であれオブジェクト形式であれ、変更の有無に関わらず、以下の条件をすべて満たす限りにおいて、成果物またはその派生成果物のコピーを複製したり頒布したりすることができます。
+
+  成果物または派生成果物の他の受領者に本ライセンスのコピーも渡すこと。
+  変更を加えたファイルについては、あなたが変更したということがよくわかるような告知を入れること。
+  ソース形式の派生成果物を頒布する場合は、ソース形式の成果物に含まれている著作権、特許、商標、および帰属についての告知を、派生成果物のどこにも関係しないものは除いて、すべて派生成果物に入れること。
+  成果物の一部として「NOTICE」に相当するテキストファイルが含まれている場合は、そうしたNOTICEファイルに含まれている帰属告知のコピーを、派生成果物のどこにも関係しないものは除いて、頒布する派生成果物に入れること。その際、次のうちの少なくとも1箇所に挿入すること。(i) 派生成果物の一部として頒布するNOTICEテキストファイル、(ii) ソース形式またはドキュメント（派生成果物と共にドキュメントを頒布する場合）、(iii) 派生成果物によって生成される表示（こうした第三者告知を盛り込むことが標準的なやり方になっている場合）。NOTICEファイルの内容はあくまで情報伝達用であって、本ライセンスを修正するものであってはなりません。あなたは頒布する派生成果物に自分の帰属告知を（成果物からのNOTICEテキストに並べて、またはその付録として）追加できますが、これはそうした追加の帰属告知が本ライセンスの修正と解釈されるおそれがない場合に限られます。
+  あなたは自分の修正物に自らの著作権表示を追加することができ、自分の修正物の使用、複製、または頒布について、あるいはそうした派生成果物の全体について、付加的なライセンス条項または異なるライセンス条項を設けることができます。ただし、これは成果物についてのあなたの使用、複製、および頒布が、それ以外の点で本ライセンスの条項に従っている場合に限られます。
+
+  5. コントリビューションの提出
+
+  特に断りがない限り、あなたが成果物への組み込みを意図してライセンサーに提出したコントリビューションは、付加的な条項がなければ、本ライセンスの条項に従うものとします。上述の規定にかかわらず、そうしたコントリビューションに関してあなたがライセンサーと結んだかもしれない別のライセンス契約の条項を、ここで無効にしたり修正したりすることはありません。
+
+  6. 商標
+
+  本ライセンスでは、成果物の出所を記述したりNOTICEファイルの内容を複製するときに必要になる妥当で慣習的な使い方は別として、ライセンサーの商号、商標、サービスマーク、または製品名の使用権を付与しません。
+
+  7. 保証の否認
+
+  適用される法律または書面での同意によって命じられない限り、ライセンサーは成果物を（そしてコントリビューターは各自のコントリビューションを）「現状のまま」提供するものとし、明示黙示を問わず、タイトル、非侵害性、商業的な使用可能性、および特定の目的に対する適合性を含め、いかなる保証も条件も提供しません。あなたは成果物の使用や再頒布の適切性を自分で判断する責任を持つと共に、本ライセンスにより付与される権利を行使することに伴うすべてのリスクを負うことになります。
+
+  8. 責任の制限
+
+  いかなる条件および法理論においても、不法行為（過失を含む）、契約、またはその他いかなる場合でも、適用される法律または書面での同意によって命じられない限り、コントリビューターは本ライセンスまたは成果物の使い方に関連して生じる直接損害、間接損害、偶発的な損害、特別損害、懲罰的損害、または結果損害を含め、営業権の損失、業務の停止、コンピューター障害または誤作動、その他の商業上の損害や損失など、いかなる損害に対しても、たとえそうした損害の可能性をたとえ知らされていたとしても、あなたに責任を負わないものとします。
+
+  9. 保証または追加的責任の引き受け
+
+  成果物またはその派生成果物を再頒布する際、あなたはサポート、保証、損害補償、またはその他の責任や、本ライセンスに矛盾しない権利を提示し、これを有料にすることができます。ただし、そうした責任を引き受ける場合、あなたはそれを自分自身のためにだけ自己責任として行えるのであって、他のコントリビューターのために行うことはできません。また、あなたはそうした保証や追加的責任のせいで他のコントリビューターに責任が降りかかったり賠償要求が出されたとしても、それらのコントリビューターに損害が及ぶのを防ぐと共に各コントリビューターの損害を補償することに同意しなければなりません。
+
+
+
+
+
+                                   Apache License
+                             Version 2.0, January 2004
+                          http://www.apache.org/licenses/
+
+     TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+     1. Definitions.
+
+        "License" shall mean the terms and conditions for use, reproduction,
+        and distribution as defined by Sections 1 through 9 of this document.
+
+        "Licensor" shall mean the copyright owner or entity authorized by
+        the copyright owner that is granting the License.
+
+        "Legal Entity" shall mean the union of the acting entity and all
+        other entities that control, are controlled by, or are under common
+        control with that entity. For the purposes of this definition,
+        "control" means (i) the power, direct or indirect, to cause the
+        direction or management of such entity, whether by contract or
+        otherwise, or (ii) ownership of fifty percent (50%) or more of the
+        outstanding shares, or (iii) beneficial ownership of such entity.
+
+        "You" (or "Your") shall mean an individual or Legal Entity
+        exercising permissions granted by this License.
+
+        "Source" form shall mean the preferred form for making modifications,
+        including but not limited to software source code, documentation
+        source, and configuration files.
+
+        "Object" form shall mean any form resulting from mechanical
+        transformation or translation of a Source form, including but
+        not limited to compiled object code, generated documentation,
+        and conversions to other media types.
+
+        "Work" shall mean the work of authorship, whether in Source or
+        Object form, made available under the License, as indicated by a
+        copyright notice that is included in or attached to the work
+        (an example is provided in the Appendix below).
+
+        "Derivative Works" shall mean any work, whether in Source or Object
+        form, that is based on (or derived from) the Work and for which the
+        editorial revisions, annotations, elaborations, or other modifications
+        represent, as a whole, an original work of authorship. For the purposes
+        of this License, Derivative Works shall not include works that remain
+        separable from, or merely link (or bind by name) to the interfaces of,
+        the Work and Derivative Works thereof.
+
+        "Contribution" shall mean any work of authorship, including
+        the original version of the Work and any modifications or additions
+        to that Work or Derivative Works thereof, that is intentionally
+        submitted to Licensor for inclusion in the Work by the copyright owner
+        or by an individual or Legal Entity authorized to submit on behalf of
+        the copyright owner. For the purposes of this definition, "submitted"
+        means any form of electronic, verbal, or written communication sent
+        to the Licensor or its representatives, including but not limited to
+        communication on electronic mailing lists, source code control systems,
+        and issue tracking systems that are managed by, or on behalf of, the
+        Licensor for the purpose of discussing and improving the Work, but
+        excluding communication that is conspicuously marked or otherwise
+        designated in writing by the copyright owner as "Not a Contribution."
+
+        "Contributor" shall mean Licensor and any individual or Legal Entity
+        on behalf of whom a Contribution has been received by Licensor and
+        subsequently incorporated within the Work.
+
+     2. Grant of Copyright License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        copyright license to reproduce, prepare Derivative Works of,
+        publicly display, publicly perform, sublicense, and distribute the
+        Work and such Derivative Works in Source or Object form.
+
+     3. Grant of Patent License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        (except as stated in this section) patent license to make, have made,
+        use, offer to sell, sell, import, and otherwise transfer the Work,
+        where such license applies only to those patent claims licensable
+        by such Contributor that are necessarily infringed by their
+        Contribution(s) alone or by combination of their Contribution(s)
+        with the Work to which such Contribution(s) was submitted. If You
+        institute patent litigation against any entity (including a
+        cross-claim or counterclaim in a lawsuit) alleging that the Work
+        or a Contribution incorporated within the Work constitutes direct
+        or contributory patent infringement, then any patent licenses
+        granted to You under this License for that Work shall terminate
+        as of the date such litigation is filed.
+
+     4. Redistribution. You may reproduce and distribute copies of the
+        Work or Derivative Works thereof in any medium, with or without
+        modifications, and in Source or Object form, provided that You
+        meet the following conditions:
+
+        (a) You must give any other recipients of the Work or
+            Derivative Works a copy of this License; and
+
+        (b) You must cause any modified files to carry prominent notices
+            stating that You changed the files; and
+
+        (c) You must retain, in the Source form of any Derivative Works
+            that You distribute, all copyright, patent, trademark, and
+            attribution notices from the Source form of the Work,
+            excluding those notices that do not pertain to any part of
+            the Derivative Works; and
+
+        (d) If the Work includes a "NOTICE" text file as part of its
+            distribution, then any Derivative Works that You distribute must
+            include a readable copy of the attribution notices contained
+            within such NOTICE file, excluding those notices that do not
+            pertain to any part of the Derivative Works, in at least one
+            of the following places: within a NOTICE text file distributed
+            as part of the Derivative Works; within the Source form or
+            documentation, if provided along with the Derivative Works; or,
+            within a display generated by the Derivative Works, if and
+            wherever such third-party notices normally appear. The contents
+            of the NOTICE file are for informational purposes only and
+            do not modify the License. You may add Your own attribution
+            notices within Derivative Works that You distribute, alongside
+            or as an addendum to the NOTICE text from the Work, provided
+            that such additional attribution notices cannot be construed
+            as modifying the License.
+
+        You may add Your own copyright statement to Your modifications and
+        may provide additional or different license terms and conditions
+        for use, reproduction, or distribution of Your modifications, or
+        for any such Derivative Works as a whole, provided Your use,
+        reproduction, and distribution of the Work otherwise complies with
+        the conditions stated in this License.
+
+     5. Submission of Contributions. Unless You explicitly state otherwise,
+        any Contribution intentionally submitted for inclusion in the Work
+        by You to the Licensor shall be under the terms and conditions of
+        this License, without any additional terms or conditions.
+        Notwithstanding the above, nothing herein shall supersede or modify
+        the terms of any separate license agreement you may have executed
+        with Licensor regarding such Contributions.
+
+     6. Trademarks. This License does not grant permission to use the trade
+        names, trademarks, service marks, or product names of the Licensor,
+        except as required for reasonable and customary use in describing the
+        origin of the Work and reproducing the content of the NOTICE file.
+
+     7. Disclaimer of Warranty. Unless required by applicable law or
+        agreed to in writing, Licensor provides the Work (and each
+        Contributor provides its Contributions) on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        implied, including, without limitation, any warranties or conditions
+        of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+        PARTICULAR PURPOSE. You are solely responsible for determining the
+        appropriateness of using or redistributing the Work and assume any
+        risks associated with Your exercise of permissions under this License.
+
+     8. Limitation of Liability. In no event and under no legal theory,
+        whether in tort (including negligence), contract, or otherwise,
+        unless required by applicable law (such as deliberate and grossly
+        negligent acts) or agreed to in writing, shall any Contributor be
+        liable to You for damages, including any direct, indirect, special,
+        incidental, or consequential damages of any character arising as a
+        result of this License or out of the use or inability to use the
+        Work (including but not limited to damages for loss of goodwill,
+        work stoppage, computer failure or malfunction, or any and all
+        other commercial damages or losses), even if such Contributor
+        has been advised of the possibility of such damages.
+
+     9. Accepting Warranty or Additional Liability. While redistributing
+        the Work or Derivative Works thereof, You may choose to offer,
+        and charge a fee for, acceptance of support, warranty, indemnity,
+        or other liability obligations and/or rights consistent with this
+        License. However, in accepting such obligations, You may act only
+        on Your own behalf and on Your sole responsibility, not on behalf
+        of any other Contributor, and only if You agree to indemnify,
+        defend, and hold each Contributor harmless for any liability
+        incurred by, or claims asserted against, such Contributor by reason
+        of your accepting any such warranty or additional liability.
+command: create-formula https://fontopo.com/fontdata/boku2b.zip

--- a/Formulas/bokutachinogothic2regular.yml
+++ b/Formulas/bokutachinogothic2regular.yml
@@ -1,0 +1,268 @@
+---
+description: BokutachinoGothic2Regular
+homepage: https://fontopo.com/
+resources:
+  BokutachinoGothic2Regular.zip:
+    urls:
+    - https://fontopo.com/fontdata/boku2r.zip
+    sha256: 7fc7d4e63c5d22c820123fcc38ceecaf93414c8f58c4b49fa3800dc63eb8b6ca
+    file_size: 1443732
+fonts:
+- name: BokutachinoGothic2Regular
+  styles:
+  - family_name: BokutachinoGothic2Regular
+    type: Regular
+    preferred_family_name: BokutachinoGothic2Regular
+    preferred_type: Regular
+    full_name: BokutachinoGothic2Regular
+    post_script_name: BokutachinoGothic2Regular
+    version: '1.01'
+    copyright: fontopo
+    font: Boku2-Regular.otf
+extract: {}
+copyright: fontopo
+open_license: |-
+  Apache License
+  Version 2.0、2004年1月
+  http://www.apache.org/licenses/
+  使用、複製、および頒布に関する条項
+
+  1. 定義
+
+  「ライセンス」とは、このドキュメントの第1項から第9項までで定義している、使用、複製、および頒布に関する条項を指します。
+
+  「ライセンサー」とは、著作権所有者、あるいは著作権所有者がライセンス付与対象として認めた者を指します。
+
+  「法人」とは、行為者と、行為者を管理するか行為者により管理されるか行為者共通の管理下にある他のすべての者とから成る連合体を指します。この定義における「管理」とは、(i) 契約またはその他により、直接または間接的にこの法人の指揮・経営を行う権限、または (ii) この法人の50%以上の株式の所有権または (iii) 受益所有権を有することを指します。
+
+  「あなた」とは、本ライセンスにより付与される権利を行使する個人または法人を指します。
+
+  「ソース」形式とは、ソフトウェアのソースコード、ドキュメントソース、設定ファイルといった、変更を加えるのに好都合な形式を指します。
+
+  「オブジェクト」形式とは、コンパイルされたオブジェクトコード、生成されたドキュメント、他のメディアへの変換物といった、ソース形式の機械的な変換により生じる形式を指します。
+
+  「成果物」とは、ソース形式であるとオブジェクト形式であるとを問わず、製作物に挿入または添付される（後出の付録に例がある）著作権表示で示された著作物で、本ライセンスに基づいて利用が許されるものを指します。
+
+  「派生成果物」とは、編集上の改訂、注解、推敲など、成果物を基にしていて全体としてオリジナル著作物と呼べるような製作物全般を指します。本ライセンスでは、成果物や派生成果物から分離できる製作物や、成果物や派生成果物のインタフェースへの単なるリンク（または名前によるバインド）を、派生成果物に含めません。
+
+  「コントリビューション」とは、成果物のオリジナルバージョンならびに成果物または派生成果物への変更や追加も含めて、著作権所有者あるいは著作権所有者が認めた個人または法人による成果物への組み込みを意図してライセンサーに提出される著作物全般を指します。この定義における「提出」とは、成果物を論じたり改良するためにライセンサーまたはその代理者により管理される電子的メーリングリスト、ソースコード管理システム、問題追跡システムといった、電子的方法、口頭、または書面で、ライセンサーまたはその代理者に情報を送ることを指します。ただし、著作権所有者が書面で「コントリビューションでない」と明示したものは除きます。
+
+  「コントリビューター」とは、ライセンサーおよびその代理を務める個人または法人で、自分のコントリビューションがライセンサーに受領されて成果物に組み込まれた者を指します。
+
+  2. 著作権ライセンスの付与
+
+  本ライセンスの条項に従って、各コントリビューターはあなたに対し、ソース形式であれオブジェクト形式であれ、成果物および派生成果物を複製したり、派生成果物を作成したり、公に表示したり、公に実行したり、サブライセンスしたり、頒布したりする、無期限で世界規模で非独占的で使用料無料で取り消し不能な著作権ライセンスを付与します。
+
+  3. 特許ライセンスの付与
+
+  本ライセンスの条項に従って、各コントリビューターはあなたに対し、成果物を作成したり、使用したり、販売したり、販売用に提供したり、インポートしたり、その他の方法で移転したりする、無期限で世界規模で非独占的で使用料無料で取り消し不能な（この項で明記したものは除く）特許ライセンスを付与します。ただし、このようなライセンスは、コントリビューターによってライセンス可能な特許申請のうち、当該コントリビューターのコントリビューションを単独または該当する成果物と組み合わせて用いることで必然的に侵害されるものにのみ適用されます。あなたが誰かに対し、交差請求や反訴を含めて、成果物あるいは成果物に組み込まれたコントリビューションが直接または間接的な特許侵害に当たるとして特許訴訟を起こした場合、本ライセンスに基づいてあなたに付与された特許ライセンスは、そうした訴訟が正式に起こされた時点で終了するものとします。
+
+  4. 再頒布
+
+  あなたは、ソース形式であれオブジェクト形式であれ、変更の有無に関わらず、以下の条件をすべて満たす限りにおいて、成果物またはその派生成果物のコピーを複製したり頒布したりすることができます。
+
+  成果物または派生成果物の他の受領者に本ライセンスのコピーも渡すこと。
+  変更を加えたファイルについては、あなたが変更したということがよくわかるような告知を入れること。
+  ソース形式の派生成果物を頒布する場合は、ソース形式の成果物に含まれている著作権、特許、商標、および帰属についての告知を、派生成果物のどこにも関係しないものは除いて、すべて派生成果物に入れること。
+  成果物の一部として「NOTICE」に相当するテキストファイルが含まれている場合は、そうしたNOTICEファイルに含まれている帰属告知のコピーを、派生成果物のどこにも関係しないものは除いて、頒布する派生成果物に入れること。その際、次のうちの少なくとも1箇所に挿入すること。(i) 派生成果物の一部として頒布するNOTICEテキストファイル、(ii) ソース形式またはドキュメント（派生成果物と共にドキュメントを頒布する場合）、(iii) 派生成果物によって生成される表示（こうした第三者告知を盛り込むことが標準的なやり方になっている場合）。NOTICEファイルの内容はあくまで情報伝達用であって、本ライセンスを修正するものであってはなりません。あなたは頒布する派生成果物に自分の帰属告知を（成果物からのNOTICEテキストに並べて、またはその付録として）追加できますが、これはそうした追加の帰属告知が本ライセンスの修正と解釈されるおそれがない場合に限られます。
+  あなたは自分の修正物に自らの著作権表示を追加することができ、自分の修正物の使用、複製、または頒布について、あるいはそうした派生成果物の全体について、付加的なライセンス条項または異なるライセンス条項を設けることができます。ただし、これは成果物についてのあなたの使用、複製、および頒布が、それ以外の点で本ライセンスの条項に従っている場合に限られます。
+
+  5. コントリビューションの提出
+
+  特に断りがない限り、あなたが成果物への組み込みを意図してライセンサーに提出したコントリビューションは、付加的な条項がなければ、本ライセンスの条項に従うものとします。上述の規定にかかわらず、そうしたコントリビューションに関してあなたがライセンサーと結んだかもしれない別のライセンス契約の条項を、ここで無効にしたり修正したりすることはありません。
+
+  6. 商標
+
+  本ライセンスでは、成果物の出所を記述したりNOTICEファイルの内容を複製するときに必要になる妥当で慣習的な使い方は別として、ライセンサーの商号、商標、サービスマーク、または製品名の使用権を付与しません。
+
+  7. 保証の否認
+
+  適用される法律または書面での同意によって命じられない限り、ライセンサーは成果物を（そしてコントリビューターは各自のコントリビューションを）「現状のまま」提供するものとし、明示黙示を問わず、タイトル、非侵害性、商業的な使用可能性、および特定の目的に対する適合性を含め、いかなる保証も条件も提供しません。あなたは成果物の使用や再頒布の適切性を自分で判断する責任を持つと共に、本ライセンスにより付与される権利を行使することに伴うすべてのリスクを負うことになります。
+
+  8. 責任の制限
+
+  いかなる条件および法理論においても、不法行為（過失を含む）、契約、またはその他いかなる場合でも、適用される法律または書面での同意によって命じられない限り、コントリビューターは本ライセンスまたは成果物の使い方に関連して生じる直接損害、間接損害、偶発的な損害、特別損害、懲罰的損害、または結果損害を含め、営業権の損失、業務の停止、コンピューター障害または誤作動、その他の商業上の損害や損失など、いかなる損害に対しても、たとえそうした損害の可能性をたとえ知らされていたとしても、あなたに責任を負わないものとします。
+
+  9. 保証または追加的責任の引き受け
+
+  成果物またはその派生成果物を再頒布する際、あなたはサポート、保証、損害補償、またはその他の責任や、本ライセンスに矛盾しない権利を提示し、これを有料にすることができます。ただし、そうした責任を引き受ける場合、あなたはそれを自分自身のためにだけ自己責任として行えるのであって、他のコントリビューターのために行うことはできません。また、あなたはそうした保証や追加的責任のせいで他のコントリビューターに責任が降りかかったり賠償要求が出されたとしても、それらのコントリビューターに損害が及ぶのを防ぐと共に各コントリビューターの損害を補償することに同意しなければなりません。
+
+
+
+
+
+                                   Apache License
+                             Version 2.0, January 2004
+                          http://www.apache.org/licenses/
+
+     TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+     1. Definitions.
+
+        "License" shall mean the terms and conditions for use, reproduction,
+        and distribution as defined by Sections 1 through 9 of this document.
+
+        "Licensor" shall mean the copyright owner or entity authorized by
+        the copyright owner that is granting the License.
+
+        "Legal Entity" shall mean the union of the acting entity and all
+        other entities that control, are controlled by, or are under common
+        control with that entity. For the purposes of this definition,
+        "control" means (i) the power, direct or indirect, to cause the
+        direction or management of such entity, whether by contract or
+        otherwise, or (ii) ownership of fifty percent (50%) or more of the
+        outstanding shares, or (iii) beneficial ownership of such entity.
+
+        "You" (or "Your") shall mean an individual or Legal Entity
+        exercising permissions granted by this License.
+
+        "Source" form shall mean the preferred form for making modifications,
+        including but not limited to software source code, documentation
+        source, and configuration files.
+
+        "Object" form shall mean any form resulting from mechanical
+        transformation or translation of a Source form, including but
+        not limited to compiled object code, generated documentation,
+        and conversions to other media types.
+
+        "Work" shall mean the work of authorship, whether in Source or
+        Object form, made available under the License, as indicated by a
+        copyright notice that is included in or attached to the work
+        (an example is provided in the Appendix below).
+
+        "Derivative Works" shall mean any work, whether in Source or Object
+        form, that is based on (or derived from) the Work and for which the
+        editorial revisions, annotations, elaborations, or other modifications
+        represent, as a whole, an original work of authorship. For the purposes
+        of this License, Derivative Works shall not include works that remain
+        separable from, or merely link (or bind by name) to the interfaces of,
+        the Work and Derivative Works thereof.
+
+        "Contribution" shall mean any work of authorship, including
+        the original version of the Work and any modifications or additions
+        to that Work or Derivative Works thereof, that is intentionally
+        submitted to Licensor for inclusion in the Work by the copyright owner
+        or by an individual or Legal Entity authorized to submit on behalf of
+        the copyright owner. For the purposes of this definition, "submitted"
+        means any form of electronic, verbal, or written communication sent
+        to the Licensor or its representatives, including but not limited to
+        communication on electronic mailing lists, source code control systems,
+        and issue tracking systems that are managed by, or on behalf of, the
+        Licensor for the purpose of discussing and improving the Work, but
+        excluding communication that is conspicuously marked or otherwise
+        designated in writing by the copyright owner as "Not a Contribution."
+
+        "Contributor" shall mean Licensor and any individual or Legal Entity
+        on behalf of whom a Contribution has been received by Licensor and
+        subsequently incorporated within the Work.
+
+     2. Grant of Copyright License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        copyright license to reproduce, prepare Derivative Works of,
+        publicly display, publicly perform, sublicense, and distribute the
+        Work and such Derivative Works in Source or Object form.
+
+     3. Grant of Patent License. Subject to the terms and conditions of
+        this License, each Contributor hereby grants to You a perpetual,
+        worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+        (except as stated in this section) patent license to make, have made,
+        use, offer to sell, sell, import, and otherwise transfer the Work,
+        where such license applies only to those patent claims licensable
+        by such Contributor that are necessarily infringed by their
+        Contribution(s) alone or by combination of their Contribution(s)
+        with the Work to which such Contribution(s) was submitted. If You
+        institute patent litigation against any entity (including a
+        cross-claim or counterclaim in a lawsuit) alleging that the Work
+        or a Contribution incorporated within the Work constitutes direct
+        or contributory patent infringement, then any patent licenses
+        granted to You under this License for that Work shall terminate
+        as of the date such litigation is filed.
+
+     4. Redistribution. You may reproduce and distribute copies of the
+        Work or Derivative Works thereof in any medium, with or without
+        modifications, and in Source or Object form, provided that You
+        meet the following conditions:
+
+        (a) You must give any other recipients of the Work or
+            Derivative Works a copy of this License; and
+
+        (b) You must cause any modified files to carry prominent notices
+            stating that You changed the files; and
+
+        (c) You must retain, in the Source form of any Derivative Works
+            that You distribute, all copyright, patent, trademark, and
+            attribution notices from the Source form of the Work,
+            excluding those notices that do not pertain to any part of
+            the Derivative Works; and
+
+        (d) If the Work includes a "NOTICE" text file as part of its
+            distribution, then any Derivative Works that You distribute must
+            include a readable copy of the attribution notices contained
+            within such NOTICE file, excluding those notices that do not
+            pertain to any part of the Derivative Works, in at least one
+            of the following places: within a NOTICE text file distributed
+            as part of the Derivative Works; within the Source form or
+            documentation, if provided along with the Derivative Works; or,
+            within a display generated by the Derivative Works, if and
+            wherever such third-party notices normally appear. The contents
+            of the NOTICE file are for informational purposes only and
+            do not modify the License. You may add Your own attribution
+            notices within Derivative Works that You distribute, alongside
+            or as an addendum to the NOTICE text from the Work, provided
+            that such additional attribution notices cannot be construed
+            as modifying the License.
+
+        You may add Your own copyright statement to Your modifications and
+        may provide additional or different license terms and conditions
+        for use, reproduction, or distribution of Your modifications, or
+        for any such Derivative Works as a whole, provided Your use,
+        reproduction, and distribution of the Work otherwise complies with
+        the conditions stated in this License.
+
+     5. Submission of Contributions. Unless You explicitly state otherwise,
+        any Contribution intentionally submitted for inclusion in the Work
+        by You to the Licensor shall be under the terms and conditions of
+        this License, without any additional terms or conditions.
+        Notwithstanding the above, nothing herein shall supersede or modify
+        the terms of any separate license agreement you may have executed
+        with Licensor regarding such Contributions.
+
+     6. Trademarks. This License does not grant permission to use the trade
+        names, trademarks, service marks, or product names of the Licensor,
+        except as required for reasonable and customary use in describing the
+        origin of the Work and reproducing the content of the NOTICE file.
+
+     7. Disclaimer of Warranty. Unless required by applicable law or
+        agreed to in writing, Licensor provides the Work (and each
+        Contributor provides its Contributions) on an "AS IS" BASIS,
+        WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+        implied, including, without limitation, any warranties or conditions
+        of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+        PARTICULAR PURPOSE. You are solely responsible for determining the
+        appropriateness of using or redistributing the Work and assume any
+        risks associated with Your exercise of permissions under this License.
+
+     8. Limitation of Liability. In no event and under no legal theory,
+        whether in tort (including negligence), contract, or otherwise,
+        unless required by applicable law (such as deliberate and grossly
+        negligent acts) or agreed to in writing, shall any Contributor be
+        liable to You for damages, including any direct, indirect, special,
+        incidental, or consequential damages of any character arising as a
+        result of this License or out of the use or inability to use the
+        Work (including but not limited to damages for loss of goodwill,
+        work stoppage, computer failure or malfunction, or any and all
+        other commercial damages or losses), even if such Contributor
+        has been advised of the possibility of such damages.
+
+     9. Accepting Warranty or Additional Liability. While redistributing
+        the Work or Derivative Works thereof, You may choose to offer,
+        and charge a fee for, acceptance of support, warranty, indemnity,
+        or other liability obligations and/or rights consistent with this
+        License. However, in accepting such obligations, You may act only
+        on Your own behalf and on Your sole responsibility, not on behalf
+        of any other Contributor, and only if You agree to indemnify,
+        defend, and hold each Contributor harmless for any liability
+        incurred by, or claims asserted against, such Contributor by reason
+        of your accepting any such warranty or additional liability.
+command: create-formula https://fontopo.com/fontdata/boku2r.zip

--- a/Formulas/buddhism.yml
+++ b/Formulas/buddhism.yml
@@ -1,0 +1,62 @@
+---
+description: Buddhism
+homepage: https://fontopo.com/
+resources:
+  Buddhism.zip:
+    urls:
+    - https://fontopo.com/fontdata/5fonts.zip
+    sha256: d72c18c782bcf9b2b6f93d8d7d442036f8a5c95ef1b9343f3554aeb166a016ca
+    file_size: 42134
+fonts:
+- name: Buddhism
+  styles:
+  - family_name: Buddhism
+    type: Regular
+    full_name: Buddhism Regular
+    post_script_name: Buddhism-Regular
+    version: '1.100'
+    copyright: No Rights Reserved
+    font: Buddhism-Regular.ttf
+- name: Flower
+  styles:
+  - family_name: Flower
+    type: Regular
+    full_name: Flower Regular
+    post_script_name: Flower-Regular
+    version: '1.100'
+    copyright: No Rights Reserved.
+    font: Flower-Regular.ttf
+- name: Happy Holiday 15px
+  styles:
+  - family_name: Happy Holiday 15px
+    type: Regular
+    full_name: Happy Holiday 15px Regular
+    post_script_name: HappyHoliday15px-Regular
+    version: '1.100'
+    copyright: No Rights Reserved.
+    font: HappyHoliday15px-Regular.ttf
+- name: Tokyo Future
+  styles:
+  - family_name: Tokyo Future
+    type: Regular
+    full_name: Tokyo Future Regular
+    post_script_name: TokyoFuture-Regular
+    version: '1.100'
+    copyright: No Rights Reserved.
+    font: TokyoFuture-Regular.ttf
+- name: Waterdrop
+  styles:
+  - family_name: Waterdrop
+    type: Regular
+    full_name: Waterdrop Regular
+    post_script_name: Waterdrop-Regular
+    version: '1.100'
+    copyright: No Rights Reserved.
+    font: Waterdrop-Regular.ttf
+extract: {}
+copyright: No Rights Reserved
+command: create-formula https://fontopo.com/fontdata/5fonts.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/cinderella.yml
+++ b/Formulas/cinderella.yml
@@ -34,7 +34,7 @@ extract: {}
 copyright: MODI
 command: create-formula https://modi.jpn.org/download/MODI_cinderella_2017_1022.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2017 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/emoir-kaku.yml
+++ b/Formulas/emoir-kaku.yml
@@ -23,7 +23,7 @@ extract: {}
 copyright: Copyright(c) 2017 M+ FONTS PROJECT/MODI
 command: create-formula https://modi.jpn.org/download/MODI_emoir-kaku_2018_063020.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2017 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/fontopofontopo.yml
+++ b/Formulas/fontopofontopo.yml
@@ -1,0 +1,28 @@
+---
+description: fontopoFONTOPO
+homepage: https://fontopo.com/
+resources:
+  fontopoFONTOPO.zip:
+    urls:
+    - https://fontopo.com/fontdata/fontopo.zip
+    sha256: 5e301a5d6e43172b15421c99b2d2c70ef4cacc0d96f58c3aa85f793a0cac5e26
+    file_size: 6824
+fonts:
+- name: fontopoFONTOPO
+  styles:
+  - family_name: fontopoFONTOPO
+    type: Regular
+    full_name: fontopoFONTOPO Regular
+    post_script_name: fontopoFONTOPO-Regular
+    version: 1.00 2012
+    description: fontopoFONTOPO Regular is a font by fontopo, designed by fontopo
+      in 2012.
+    copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+    font: fontopoFONTOPO-Regular.otf
+extract: {}
+copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+command: create-formula https://fontopo.com/fontdata/fontopo.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/fontoponeutral.yml
+++ b/Formulas/fontoponeutral.yml
@@ -1,0 +1,28 @@
+---
+description: fontopoNEUTRAL
+homepage: https://fontopo.com/
+resources:
+  fontopoNEUTRAL.zip:
+    urls:
+    - https://fontopo.com/fontdata/neutral.zip
+    sha256: 6746a8c7bea018b79cc2b82508b187f16d2e0279d19ada6f1ac9da5e16e45fb7
+    file_size: 6218
+fonts:
+- name: fontopoNEUTRAL
+  styles:
+  - family_name: fontopoNEUTRAL
+    type: Regular
+    full_name: fontopoNEUTRAL Regular
+    post_script_name: fontopoNEUTRAL-Regular
+    version: 1.00 2012
+    description: fontopoNEUTRAL Regular is a font by fontopo, designed by fontopo
+      in 2012.
+    copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+    font: fontopoNEUTRAL-Regular.otf
+extract: {}
+copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+command: create-formula https://fontopo.com/fontdata/neutral.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/fontoponihongo.yml
+++ b/Formulas/fontoponihongo.yml
@@ -1,0 +1,68 @@
+---
+description: FontopoNIHONGO
+homepage: https://fontopo.com/
+resources:
+  FontopoNIHONGO.zip:
+    urls:
+    - https://fontopo.com/fontdata/nihongo.zip
+    sha256: b11b0c03ea7e3494cae58662d97f5bb4c7e7d705aabb267aa9b1f90dde1e6be4
+    file_size: 1502499
+fonts:
+- name: FontopoNIHONGO
+  styles:
+  - family_name: FontopoNIHONGO
+    type: Regular
+    preferred_family_name: FontopoNIHONGO
+    preferred_type: Regular
+    full_name: FontopoNIHONGO
+    post_script_name: FontopoNIHONGO
+    version: '1.10'
+    copyright: Fontopo
+    font: FontopoNIHONGO.otf
+extract: {}
+copyright: Fontopo
+command: create-formula https://fontopo.com/fontdata/nihongo.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  IPA FONT LICENSE AGREEMENT V1.0
+  The Licensor provides the Licensed Program (as defined in Article 1 below) under the terms of this license agreement (“Agreement”). Any use, reproduction or distribution of the Licensed Program, or any exercise of rights under this Agreement by a Recipient ( (as defined in Article 1 below) constitutes the Recipient's acceptance of this Agreement.
+  Article 1 (Definitions)
+  1. “Digital Font Program” shall mean a computer program containing, or used to render or display fonts.
+  2. “Licensed Program” shall mean a Digital Font Program licensed by the Licensor under this Agreement.
+  3. “Derived Program” shall mean a Digital Font Program created as a result of a modification, addition, deletion, replacement or any other adaptation to or of a part or all of the Licensed Program, and includes a case where a Digital Font Program newly created by retrieving font information from a part or all of the Licensed Program or Embedded Fonts from a Digital Document File with or without modification of the retrieved font information.
+  4. “Digital Content” shall mean products provided to end users in the form of digital data, including video content, motion and/or still pictures, TV programs or other broadcasting content and products consisting of character text, pictures, photographic images, graphic symbols and /or the like.
+  5. “Digital Document File” shall mean a PDF file or other Digital Content created by various software programs in which a part or all of the Licensed Program becomes embedded or contained in the file for the display of the font (“Embedded Fonts”). Fonts are used only in the display of characters in the particular Digital Document File within which they are embedded, and shall be distinguished from those in any Digital Font Program, which may be used for display of characters outside that particular Digital Document File.
+  6. “Computer” shall include a server in this Agreement.
+  7. “Reproduction and Other Exploitation” shall mean reproduction, transfer, distribution, lease, public transmission, presentation, exhibition, adaptation and any other exploitation.
+  8. “Recipient” shall mean anyone who receives the Licensed Program under this Agreement, including one that receives the Licensed Program from a Recipient.
+  Article 2 (Grant of License)
+  The Licensor grants to the Recipient a license to use the Licensed Program in any and all countries in accordance with each of the provisions set forth in this Agreement. no sense is this Agreement intended to transfer any right relating to the Licensed Program held by the Licensor except as specifically set forth herein or any right relating to any trademark, trade name, or service mark to the Recipient.
+  1. The Recipient may install the Licensed Program on any number of Computers and use the same in accordance with the provisions set forth in this Agreement.
+  2. The Recipient may use the Licensed Program, with or without modification in printed materials or in Digital Content as an expression of character texts or the like.
+  3. The Recipient may conduct Reproduction and Other Exploitation of the printed materials and Digital Content created in accordance with the preceding Paragraph, for commercial or non-commercial purposes and in any form of media including but not limited to broadcasting, communication and various recording media.
+  4. If any Recipient extracts Embedded Fonts from a Digital Document File to create a Derived Program, such Derived Program shall be subject to the terms of this agreement.
+  5. If any Recipient performs Reproduction or Other Exploitation of a Digital Document File in which Embedded Fonts of the Licensed Program are used only for rendering the Digital Content within such Digital Document File then such Recipient shall have no further obligations under this Agreement in relation to such actions .
+  6. The Recipient may reproduce the Licensed Program as is without modification and transfer such copies, publicly transmit or otherwise redistribute the Licensed Program to a third party for commercial or non-commercial purposes (“Redistribute”), in accordance with the provisions set forth in Article 3 Paragraph 2.
+  7. The Recipient may create, use, reproduce and/or Redistribute a Derived Program under the terms stated above for the Licensed Program: provided, that the Recipient shall follow the provisions set forth in Article 3 Paragraph 1 when Redistributing the Derived Program.
+  Article 3 (Restrictions)
+  The license granted in the preceding Article shall be subject to the following restrictions:
+  1. If a Derived Program is Redistributed pursuant to Paragraph 4 and 7 of the preceding Article, the following conditions must be met:
+     (1) The following must be also Redistributed together with the Derived Program, or be made available online or by means of mailing mechanisms in exchange for a cost which does not exceed the total costs of postage, storage medium and handling fees:
+         (a) a copy of the Derived Program; and
+         (b) any additional file created by the font developing program in the course of creating the Derived Program that can be used for further modification of the Derived Program, if any.
+     (2) It is required to also Redistribute means to enable recipients of the Derived Program to replace the Derived Program with the Licensed Program first released under this License (the “Original Program”). Original Program, or instructions setting out a method to replace the Derived Program with the Original Program.
+     (3) The Recipient must license the Derived Program under the terms and conditions of this Agreement.
+     (4) No one may use or include the name of the Licensed Program as a program name, font name or file name of the Derived Program.
+     (5) Any material to be made available online or by means of mailing a medium to satisfy the requirements of this paragraph may be provided, verbatim, by any party wishing to do so.
+  2. If the Recipient Redistributes the Licensed Program pursuant to Paragraph 6 of the preceding Article, the Recipient shall meet all of the following conditions:
+     (1) The Recipient may not change the name of the Licensed Program.
+     (2) The Recipient may not alter or otherwise modify the Licensed Program.
+     (3) The Recipient must attach a copy of this Agreement to the Licensed Program.
+  3. THIS LICENSED PROGRAM IS PROVIDED BY THE LICENSOR “AS IS” AND ANY EXPRESSED OR IMPLIED WARRANTY AS TO THE LICENSED PROGRAM OR ANY DERIVED PROGRAM, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE, ARE DISCLAIMED. IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXTENDED, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO; PROCUREMENT OF SUBSTITUTED GOODS OR SERVICE; DAMAGES ARISING FROM SYSTEM FAILURE LOSS OR CORRUPTION OF EXISTING DATA OR PROGRAM; LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE INSTALLATION, USE,THE REPRODUCTION OR OTHER EXPLOITATION OF THE LICENSED PROGRAM OR ANY DERIVED PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+  4. The Licensor is under no obligation to respond to any technical questions or inquiries, or provide any other user support in connection with the installation, use or the Reproduction and Other Exploitation of the Licensed Program or Derived Programs thereof.
+  Article 4 (Termination of Agreement)
+  1. The term of this Agreement shall begin from the time of receipt of the Licensed Program by the Recipient and shall continue as long as the Recipient retains any such Licensed Program in any way.
+  2. Notwithstanding the provision set forth in the preceding Paragraph, in the event of the breach of any of the provisions set forth in this Agreement by the Recipient, this Agreement shall automatically terminate without any notice. use or conduct Reproduction and Other Exploitation of the Licensed Program or a Derived Program: provided that such termination shall not affect any rights of any other Recipient receiving the Licensed Program or the Derived Program from such Recipient who breached this Agreement.
+  Article 5 (Governing Law)
+  1. In such an event, the Recipient may select either this Agreement or any subsequent version of the Agreement in using, conducting the Reproduction and Other Exploitation of, or Redistributing the Licensed Program or a Derived Program. Other matters not specified above shall be subject to the Copyright Law of Japan and other related laws and regulations of Japan.
+  2. This Agreement shall be constructed under the laws of Japan.

--- a/Formulas/fontoponikukyu.yml
+++ b/Formulas/fontoponikukyu.yml
@@ -1,0 +1,28 @@
+---
+description: FontopoNIKUKYU
+homepage: https://fontopo.com/
+resources:
+  FontopoNIKUKYU.zip:
+    urls:
+    - https://fontopo.com/fontdata/nikukyu.zip
+    sha256: b59f2806f874e74d29bb8bdf44dfc900de1cc89a5bc4ec1996ec5511afc86417
+    file_size: 11151
+fonts:
+- name: FontopoNIKUKYU
+  styles:
+  - family_name: FontopoNIKUKYU
+    type: Regular
+    preferred_family_name: FontopoNIKUKYU
+    preferred_type: Regular
+    full_name: FontopoNIKUKYU
+    post_script_name: FontopoNIKUKYU
+    version: '1.00'
+    copyright: Fontopo
+    font: FontopoNIKUKYU.otf
+extract: {}
+copyright: Fontopo
+command: create-formula https://fontopo.com/fontdata/nikukyu.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/fontopooriental.yml
+++ b/Formulas/fontopooriental.yml
@@ -1,0 +1,28 @@
+---
+description: FontopoORIENTAL
+homepage: https://fontopo.com/
+resources:
+  FontopoORIENTAL.zip:
+    urls:
+    - https://fontopo.com/fontdata/oriental.zip
+    sha256: 02e86fbbe2fc2688ac84b9cba51832712b67d1b8bc896bb8a477efe54868c7cd
+    file_size: 6518
+fonts:
+- name: FontopoORIENTAL
+  styles:
+  - family_name: FontopoORIENTAL
+    type: Regular
+    preferred_family_name: FontopoORIENTAL
+    preferred_type: Regular
+    full_name: FontopoORIENTAL
+    post_script_name: FontopoORIENTAL
+    version: '1.00'
+    copyright: Fontopo
+    font: FontopoORIENTAL.otf
+extract: {}
+copyright: Fontopo
+command: create-formula https://fontopo.com/fontdata/oriental.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/fontoposolid.yml
+++ b/Formulas/fontoposolid.yml
@@ -1,0 +1,28 @@
+---
+description: fontopoSOLID
+homepage: https://fontopo.com/
+resources:
+  fontopoSOLID.zip:
+    urls:
+    - https://fontopo.com/fontdata/solid.zip
+    sha256: 4920c5b5e945dc298b30474135d0e734e23c49f333ad630d2c40d3b0c9bb3693
+    file_size: 6923
+fonts:
+- name: fontopoSOLID
+  styles:
+  - family_name: fontopoSOLID
+    type: Regular
+    full_name: fontopoSOLID Regular
+    post_script_name: fontopoSOLID-Regular
+    version: 1.00 2012
+    description: fontopoSOLID Regular is a font by fontopo, designed by fontopo in
+      2012.
+    copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+    font: fontopoSOLID-Regular.otf
+extract: {}
+copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+command: create-formula https://fontopo.com/fontdata/solid.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/fontoposubway.yml
+++ b/Formulas/fontoposubway.yml
@@ -1,0 +1,28 @@
+---
+description: fontopoSUBWAY
+homepage: https://fontopo.com/
+resources:
+  fontopoSUBWAY.zip:
+    urls:
+    - https://fontopo.com/fontdata/subway.zip
+    sha256: caea8272677d23470aff6746d932fac4f4cc05691638a79362b6302b36f7fe3c
+    file_size: 10794
+fonts:
+- name: fontopoSUBWAY
+  styles:
+  - family_name: fontopoSUBWAY
+    type: Regular
+    full_name: fontopoSUBWAY Regular
+    post_script_name: fontopoSUBWAY-Regular
+    version: 1.00 2012
+    description: fontopoSUBWAY Regular is a font by fontopo, designed by fontopo in
+      2012.
+    copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+    font: fontopoSUBWAY-Regular.otf
+extract: {}
+copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+command: create-formula https://fontopo.com/fontdata/subway.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/fontoposunnyday.yml
+++ b/Formulas/fontoposunnyday.yml
@@ -1,0 +1,28 @@
+---
+description: fontopoSunnyDay
+homepage: https://fontopo.com/
+resources:
+  fontopoSunnyDay.zip:
+    urls:
+    - https://fontopo.com/fontdata/sunnyday.zip
+    sha256: 82bcd7b2609fa6c9ddf4360eec44abed1142544fbf2038bcb6818276b91f7a95
+    file_size: 11623
+fonts:
+- name: fontopoSunnyDay
+  styles:
+  - family_name: fontopoSunnyDay
+    type: Regular
+    full_name: fontopoSunnyDay Regular
+    post_script_name: fontopoSunnyDay-Regular
+    version: 1.00 2012
+    description: fontopoSunnyDay Regular is a font by fontopo, designed by fontopo
+      in 2012.
+    copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+    font: fontopoSunnyDay-Regular.otf
+extract: {}
+copyright: Copyright (c) 2012 by fontopo. All rights reserved.
+command: create-formula https://fontopo.com/fontdata/sunnyday.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/genkaimincho.yml
+++ b/Formulas/genkaimincho.yml
@@ -1,0 +1,120 @@
+---
+description: Genkaimincho
+homepage: https://www.flopdesign.com/
+resources:
+  Genkaimincho.zip:
+    urls:
+    - http://flop.sakura.ne.jp/font/fontdata/Genkai-Mincho-font.zip
+    sha256: 2608f5fac4b8d1908413efb4130839d873525e666687279b1c0a2cd7affee90b
+    file_size: 13584125
+fonts:
+- name: Genkaimincho
+  styles:
+  - family_name: Genkaimincho
+    type: Regular
+    preferred_family_name: Genkaimincho
+    preferred_type: Regular
+    full_name: Genkaimincho
+    post_script_name: Genkaimincho
+    version: '1.00'
+    description: Dr. Ken Lunde (project architect, glyph set definition & overall
+      production); Masataka HATTORI 服部正貴 (production & ideograph elements)
+    copyright: Adobe Systems Incorporated
+    font: genkai-mincho.ttf
+extract: {}
+copyright: Adobe Systems Incorporated
+license_url: http://scripts.sil.org/OFL
+open_license: |-
+  This Font Software is licensed under the SIL Open Font License,
+  Version 1.1.
+
+  This license is copied below, and is also available with a FAQ at:
+  http://scripts.sil.org/OFL
+
+  -----------------------------------------------------------
+  SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+  -----------------------------------------------------------
+
+  PREAMBLE
+  The goals of the Open Font License (OFL) are to stimulate worldwide
+  development of collaborative font projects, to support the font
+  creation efforts of academic and linguistic communities, and to
+  provide a free and open framework in which fonts may be shared and
+  improved in partnership with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and
+  redistributed freely as long as they are not sold by themselves. The
+  fonts, including any derivative works, can be bundled, embedded,
+  redistributed and/or sold with any software provided that any reserved
+  names are not used by derivative works. The fonts and derivatives,
+  however, cannot be released under any other type of license. The
+  requirement for fonts to remain under this license does not apply to
+  any document created using the fonts or their derivatives.
+
+  DEFINITIONS
+  "Font Software" refers to the set of files released by the Copyright
+  Holder(s) under this license and clearly marked as such. This may
+  include source files, build scripts and documentation.
+
+  "Reserved Font Name" refers to any names specified as such after the
+  copyright statement(s).
+
+  "Original Version" refers to the collection of Font Software
+  components as distributed by the Copyright Holder(s).
+
+  "Modified Version" refers to any derivative made by adding to,
+  deleting, or substituting -- in part or in whole -- any of the
+  components of the Original Version, by changing formats or by porting
+  the Font Software to a new environment.
+
+  "Author" refers to any designer, engineer, programmer, technical
+  writer or other person who contributed to the Font Software.
+
+  PERMISSION & CONDITIONS
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of the Font Software, to use, study, copy, merge, embed,
+  modify, redistribute, and sell modified and unmodified copies of the
+  Font Software, subject to the following conditions:
+
+  1) Neither the Font Software nor any of its individual components, in
+  Original or Modified Versions, may be sold by itself.
+
+  2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+  3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the
+  corresponding Copyright Holder. This restriction only applies to the
+  primary font name as presented to the users.
+
+  4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+  5) The Font Software, modified or unmodified, in part or in whole,
+  must be distributed entirely under this license, and must not be
+  distributed under any other license. The requirement for fonts to
+  remain under this license does not apply to any document created using
+  the Font Software.
+
+  TERMINATION
+  This license becomes null and void if any of the above conditions are
+  not met.
+
+  DISCLAIMER
+  THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+  OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+  DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+  OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula http://flop.sakura.ne.jp/font/fontdata/Genkai-Mincho-font.zip

--- a/Formulas/harenosoramincho.yml
+++ b/Formulas/harenosoramincho.yml
@@ -1,0 +1,68 @@
+---
+description: HarenosoraMincho
+homepage: https://fontopo.com/
+resources:
+  HarenosoraMincho.zip:
+    urls:
+    - https://fontopo.com/fontdata/hare.zip
+    sha256: a1bef59309f1816fefc6dffc4decbeafb6449be636140e4c93c97e993acfc1e8
+    file_size: 2600379
+fonts:
+- name: HarenosoraMincho
+  styles:
+  - family_name: HarenosoraMincho
+    type: Regular
+    preferred_family_name: HarenosoraMincho
+    preferred_type: Regular
+    full_name: HarenosoraMincho
+    post_script_name: HarenosoraMincho
+    version: '1.00'
+    copyright: fontopo
+    font: Harenosora.otf
+extract: {}
+copyright: fontopo
+command: create-formula https://fontopo.com/fontdata/hare.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  IPA FONT LICENSE AGREEMENT V1.0
+  The Licensor provides the Licensed Program (as defined in Article 1 below) under the terms of this license agreement (“Agreement”). Any use, reproduction or distribution of the Licensed Program, or any exercise of rights under this Agreement by a Recipient ( (as defined in Article 1 below) constitutes the Recipient's acceptance of this Agreement.
+  Article 1 (Definitions)
+  1. “Digital Font Program” shall mean a computer program containing, or used to render or display fonts.
+  2. “Licensed Program” shall mean a Digital Font Program licensed by the Licensor under this Agreement.
+  3. “Derived Program” shall mean a Digital Font Program created as a result of a modification, addition, deletion, replacement or any other adaptation to or of a part or all of the Licensed Program, and includes a case where a Digital Font Program newly created by retrieving font information from a part or all of the Licensed Program or Embedded Fonts from a Digital Document File with or without modification of the retrieved font information.
+  4. “Digital Content” shall mean products provided to end users in the form of digital data, including video content, motion and/or still pictures, TV programs or other broadcasting content and products consisting of character text, pictures, photographic images, graphic symbols and /or the like.
+  5. “Digital Document File” shall mean a PDF file or other Digital Content created by various software programs in which a part or all of the Licensed Program becomes embedded or contained in the file for the display of the font (“Embedded Fonts”). Fonts are used only in the display of characters in the particular Digital Document File within which they are embedded, and shall be distinguished from those in any Digital Font Program, which may be used for display of characters outside that particular Digital Document File.
+  6. “Computer” shall include a server in this Agreement.
+  7. “Reproduction and Other Exploitation” shall mean reproduction, transfer, distribution, lease, public transmission, presentation, exhibition, adaptation and any other exploitation.
+  8. “Recipient” shall mean anyone who receives the Licensed Program under this Agreement, including one that receives the Licensed Program from a Recipient.
+  Article 2 (Grant of License)
+  The Licensor grants to the Recipient a license to use the Licensed Program in any and all countries in accordance with each of the provisions set forth in this Agreement. no sense is this Agreement intended to transfer any right relating to the Licensed Program held by the Licensor except as specifically set forth herein or any right relating to any trademark, trade name, or service mark to the Recipient.
+  1. The Recipient may install the Licensed Program on any number of Computers and use the same in accordance with the provisions set forth in this Agreement.
+  2. The Recipient may use the Licensed Program, with or without modification in printed materials or in Digital Content as an expression of character texts or the like.
+  3. The Recipient may conduct Reproduction and Other Exploitation of the printed materials and Digital Content created in accordance with the preceding Paragraph, for commercial or non-commercial purposes and in any form of media including but not limited to broadcasting, communication and various recording media.
+  4. If any Recipient extracts Embedded Fonts from a Digital Document File to create a Derived Program, such Derived Program shall be subject to the terms of this agreement.
+  5. If any Recipient performs Reproduction or Other Exploitation of a Digital Document File in which Embedded Fonts of the Licensed Program are used only for rendering the Digital Content within such Digital Document File then such Recipient shall have no further obligations under this Agreement in relation to such actions .
+  6. The Recipient may reproduce the Licensed Program as is without modification and transfer such copies, publicly transmit or otherwise redistribute the Licensed Program to a third party for commercial or non-commercial purposes (“Redistribute”), in accordance with the provisions set forth in Article 3 Paragraph 2.
+  7. The Recipient may create, use, reproduce and/or Redistribute a Derived Program under the terms stated above for the Licensed Program: provided, that the Recipient shall follow the provisions set forth in Article 3 Paragraph 1 when Redistributing the Derived Program.
+  Article 3 (Restrictions)
+  The license granted in the preceding Article shall be subject to the following restrictions:
+  1. If a Derived Program is Redistributed pursuant to Paragraph 4 and 7 of the preceding Article, the following conditions must be met:
+     (1) The following must be also Redistributed together with the Derived Program, or be made available online or by means of mailing mechanisms in exchange for a cost which does not exceed the total costs of postage, storage medium and handling fees:
+         (a) a copy of the Derived Program; and
+         (b) any additional file created by the font developing program in the course of creating the Derived Program that can be used for further modification of the Derived Program, if any.
+     (2) It is required to also Redistribute means to enable recipients of the Derived Program to replace the Derived Program with the Licensed Program first released under this License (the “Original Program”). Original Program, or instructions setting out a method to replace the Derived Program with the Original Program.
+     (3) The Recipient must license the Derived Program under the terms and conditions of this Agreement.
+     (4) No one may use or include the name of the Licensed Program as a program name, font name or file name of the Derived Program.
+     (5) Any material to be made available online or by means of mailing a medium to satisfy the requirements of this paragraph may be provided, verbatim, by any party wishing to do so.
+  2. If the Recipient Redistributes the Licensed Program pursuant to Paragraph 6 of the preceding Article, the Recipient shall meet all of the following conditions:
+     (1) The Recipient may not change the name of the Licensed Program.
+     (2) The Recipient may not alter or otherwise modify the Licensed Program.
+     (3) The Recipient must attach a copy of this Agreement to the Licensed Program.
+  3. THIS LICENSED PROGRAM IS PROVIDED BY THE LICENSOR “AS IS” AND ANY EXPRESSED OR IMPLIED WARRANTY AS TO THE LICENSED PROGRAM OR ANY DERIVED PROGRAM, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE, ARE DISCLAIMED. IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXTENDED, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO; PROCUREMENT OF SUBSTITUTED GOODS OR SERVICE; DAMAGES ARISING FROM SYSTEM FAILURE LOSS OR CORRUPTION OF EXISTING DATA OR PROGRAM; LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE INSTALLATION, USE,THE REPRODUCTION OR OTHER EXPLOITATION OF THE LICENSED PROGRAM OR ANY DERIVED PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+  4. The Licensor is under no obligation to respond to any technical questions or inquiries, or provide any other user support in connection with the installation, use or the Reproduction and Other Exploitation of the Licensed Program or Derived Programs thereof.
+  Article 4 (Termination of Agreement)
+  1. The term of this Agreement shall begin from the time of receipt of the Licensed Program by the Recipient and shall continue as long as the Recipient retains any such Licensed Program in any way.
+  2. Notwithstanding the provision set forth in the preceding Paragraph, in the event of the breach of any of the provisions set forth in this Agreement by the Recipient, this Agreement shall automatically terminate without any notice. use or conduct Reproduction and Other Exploitation of the Licensed Program or a Derived Program: provided that such termination shall not affect any rights of any other Recipient receiving the Licensed Program or the Derived Program from such Recipient who breached this Agreement.
+  Article 5 (Governing Law)
+  1. In such an event, the Recipient may select either this Agreement or any subsequent version of the Agreement in using, conducting the Reproduction and Other Exploitation of, or Redistributing the Licensed Program or a Derived Program. Other matters not specified above shall be subject to the Copyright Law of Japan and other related laws and regulations of Japan.
+  2. This Agreement shall be constructed under the laws of Japan.

--- a/Formulas/hizumin-kana.yml
+++ b/Formulas/hizumin-kana.yml
@@ -1,5 +1,6 @@
 ---
 description: hizumin-kana
+homepage: https://modi.jpn.org/
 resources:
   hizumin-kana.zip:
     urls:
@@ -22,7 +23,7 @@ extract: {}
 copyright: MODI
 command: create-formula https://modi.jpn.org/download/MODI_hizumin-kana_2017_0213.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2017 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/ipa.yml
+++ b/Formulas/ipa.yml
@@ -62,7 +62,7 @@ copyright: Copyright(c) Information-technology Promotion Agency, Japan (IPA), 20
   product.
 license_url: http://ipafont.ipa.go.jp/ipa_font_license_v1.html
 command: create-formula https://moji.or.jp/wp-content/ipafont/IPAfont/IPAfont00303.zip
-requires_license_agreement: |
+open_license: |
   IPA FONT LICENSE AGREEMENT V1.0
   The Licensor provides the Licensed Program (as defined in Article 1 below) under the terms of this license agreement (“Agreement”). Any use, reproduction or distribution of the Licensed Program, or any exercise of rights under this Agreement by a Recipient ( (as defined in Article 1 below) constitutes the Recipient's acceptance of this Agreement.
   Article 1 (Definitions)

--- a/Formulas/ipaex.yml
+++ b/Formulas/ipaex.yml
@@ -38,7 +38,7 @@ copyright: Copyright(c) Information-technology Promotion Agency, Japan (IPA), 20
   You must accept "https://opensource.org/licenses/IPA/" to use this product.
 license_url: https://opensource.org/licenses/IPA/
 command: create-formula https://moji.or.jp/wp-content/ipafont/IPAexfont/IPAexfont00401.zip
-requires_license_agreement: |
+open_license: |
   IPA FONT LICENSE AGREEMENT V1.0
   The Licensor provides the Licensed Program (as defined in Article 1 below) under the terms of this license agreement (“Agreement”). Any use, reproduction or distribution of the Licensed Program, or any exercise of rights under this Agreement by a Recipient ( (as defined in Article 1 below) constitutes the Recipient's acceptance of this Agreement.
   Article 1 (Definitions)

--- a/Formulas/iroha-mochi.yml
+++ b/Formulas/iroha-mochi.yml
@@ -1,5 +1,6 @@
 ---
 description: iroha-mochi
+homepage: https://modi.jpn.org/
 resources:
   iroha-mochi.zip:
     urls:
@@ -22,7 +23,7 @@ extract: {}
 copyright: MODI
 command: create-formula https://modi.jpn.org/download/MODI_iroha-mochi_2018_0112.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2018 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/irohakakuc.yml
+++ b/Formulas/irohakakuc.yml
@@ -77,3 +77,98 @@ extract: {}
 copyright: "[Source Han Sans]"
 license_url: http://scripts.sil.org/OFL
 command: create-formula https://modi.jpn.org/download/MODI_irohakakuC_2016_0904.zip
+license_url: https://modi.jpn.org/licence.php
+open_license: |-
+  Copyright (c) 2016 M+ FONTS PROJECT/MODI
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at:
+  https://openfontlicense.org
+
+
+  -----------------------------------------------------------
+  SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+  -----------------------------------------------------------
+
+  PREAMBLE
+  The goals of the Open Font License (OFL) are to stimulate worldwide
+  development of collaborative font projects, to support the font creation
+  efforts of academic and linguistic communities, and to provide a free and
+  open framework in which fonts may be shared and improved in partnership
+  with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and
+  redistributed freely as long as they are not sold by themselves. The
+  fonts, including any derivative works, can be bundled, embedded,
+  redistributed and/or sold with any software provided that any reserved
+  names are not used by derivative works. The fonts and derivatives,
+  however, cannot be released under any other type of license. The
+  requirement for fonts to remain under this license does not apply
+  to any document created using the fonts or their derivatives.
+
+  DEFINITIONS
+  "Font Software" refers to the set of files released by the Copyright
+  Holder(s) under this license and clearly marked as such. This may
+  include source files, build scripts and documentation.
+
+  "Reserved Font Name" refers to any names specified as such after the
+  copyright statement(s).
+
+  "Original Version" refers to the collection of Font Software components as
+  distributed by the Copyright Holder(s).
+
+  "Modified Version" refers to any derivative made by adding to, deleting,
+  or substituting -- in part or in whole -- any of the components of the
+  Original Version, by changing formats or by porting the Font Software to a
+  new environment.
+
+  "Author" refers to any designer, engineer, programmer, technical
+  writer or other person who contributed to the Font Software.
+
+  PERMISSION & CONDITIONS
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of the Font Software, to use, study, copy, merge, embed, modify,
+  redistribute, and sell modified and unmodified copies of the Font
+  Software, subject to the following conditions:
+
+  1) Neither the Font Software nor any of its individual components,
+  in Original or Modified Versions, may be sold by itself.
+
+  2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+  3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the corresponding
+  Copyright Holder. This restriction only applies to the primary font name as
+  presented to the users.
+
+  4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+  5) The Font Software, modified or unmodified, in part or in whole,
+  must be distributed entirely under this license, and must not be
+  distributed under any other license. The requirement for fonts to
+  remain under this license does not apply to any document created
+  using the Font Software.
+
+  TERMINATION
+  This license becomes null and void if any of the above conditions are
+  not met.
+
+  DISCLAIMER
+  THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+  OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+  DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+  OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/Formulas/irohamaru.yml
+++ b/Formulas/irohamaru.yml
@@ -1,5 +1,6 @@
 ---
 description: irohamaru
+homepage: https://modi.jpn.org/
 resources:
   irohamaru.zip:
     urls:
@@ -50,3 +51,98 @@ extract: {}
 copyright: "[Source Han Sans]"
 license_url: http://scripts.sil.org/OFL
 command: create-formula https://modi.jpn.org/download/MODI_irohamaru_2016_0727.zip
+license_url: https://modi.jpn.org/licence.php
+open_license: |-
+  Copyright (c) 2016 M+ FONTS PROJECT
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at:
+  https://openfontlicense.org
+
+
+  -----------------------------------------------------------
+  SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+  -----------------------------------------------------------
+
+  PREAMBLE
+  The goals of the Open Font License (OFL) are to stimulate worldwide
+  development of collaborative font projects, to support the font creation
+  efforts of academic and linguistic communities, and to provide a free and
+  open framework in which fonts may be shared and improved in partnership
+  with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and
+  redistributed freely as long as they are not sold by themselves. The
+  fonts, including any derivative works, can be bundled, embedded,
+  redistributed and/or sold with any software provided that any reserved
+  names are not used by derivative works. The fonts and derivatives,
+  however, cannot be released under any other type of license. The
+  requirement for fonts to remain under this license does not apply
+  to any document created using the fonts or their derivatives.
+
+  DEFINITIONS
+  "Font Software" refers to the set of files released by the Copyright
+  Holder(s) under this license and clearly marked as such. This may
+  include source files, build scripts and documentation.
+
+  "Reserved Font Name" refers to any names specified as such after the
+  copyright statement(s).
+
+  "Original Version" refers to the collection of Font Software components as
+  distributed by the Copyright Holder(s).
+
+  "Modified Version" refers to any derivative made by adding to, deleting,
+  or substituting -- in part or in whole -- any of the components of the
+  Original Version, by changing formats or by porting the Font Software to a
+  new environment.
+
+  "Author" refers to any designer, engineer, programmer, technical
+  writer or other person who contributed to the Font Software.
+
+  PERMISSION & CONDITIONS
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of the Font Software, to use, study, copy, merge, embed, modify,
+  redistribute, and sell modified and unmodified copies of the Font
+  Software, subject to the following conditions:
+
+  1) Neither the Font Software nor any of its individual components,
+  in Original or Modified Versions, may be sold by itself.
+
+  2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+  3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the corresponding
+  Copyright Holder. This restriction only applies to the primary font name as
+  presented to the users.
+
+  4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+  5) The Font Software, modified or unmodified, in part or in whole,
+  must be distributed entirely under this license, and must not be
+  distributed under any other license. The requirement for fonts to
+  remain under this license does not apply to any document created
+  using the Font Software.
+
+  TERMINATION
+  This license becomes null and void if any of the above conditions are
+  not met.
+
+  DISCLAIMER
+  THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+  OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+  DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+  OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/Formulas/irohamaru_mikami.yml
+++ b/Formulas/irohamaru_mikami.yml
@@ -45,7 +45,7 @@ extract: {}
 copyright: Copyright(c) 2015 M+ FONTS PROJECT
 command: create-formula https://modi.jpn.org/download/MODI_irohamaru-mikami_2016_0914.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2015 M+ FONTS PROJECT
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/joongnajoche.yml
+++ b/Formulas/joongnajoche.yml
@@ -1,0 +1,58 @@
+---
+description: Joongnajoche
+resources:
+  Joongnajoche.zip:
+    urls:
+    - https://go.aws/2u0lUvZ
+    sha256: 88816f23d862d0207b81bd78565fd62754ef7ccf18534b7d6a704b75065192f8
+    file_size: 18617006
+fonts:
+- name: Joongnajoche Light
+  styles:
+  - family_name: Joongnajoche Light
+    type: Regular
+    preferred_family_name: Joongnajoche
+    preferred_type: Light
+    full_name: Joongnajoche Light
+    post_script_name: JoongnajocheL-KSCpc-EUC-H
+    version: '1.0'
+    copyright: "©Joonggonara Corp. All Rights Reserved."
+    font: 중나좋체 Light.ttf
+- name: Joongnajoche Light OTF
+  styles:
+  - family_name: Joongnajoche Light OTF
+    type: Regular
+    preferred_family_name: Joongnajoche OTF
+    preferred_type: Light
+    full_name: JoongnajocheStd-L
+    post_script_name: JoongnajocheStd-L
+    version: '1.0'
+    description: JoonggonaraFonts Opentype Package
+    copyright: "©Joonggonara Corp. All Rights Reserved."
+    font: 중나좋체 OTF Light.otf
+- name: Joongnajoche Medium
+  styles:
+  - family_name: Joongnajoche Medium
+    type: Regular
+    preferred_family_name: Joongnajoche
+    preferred_type: Medium
+    full_name: Joongnajoche Medium
+    post_script_name: JoongnajocheM-KSCpc-EUC-H
+    version: '1.0'
+    copyright: "©Joonggonara Corp. All Rights Reserved."
+    font: 중나좋체 Medium.ttf
+- name: Joongnajoche Medium OTF
+  styles:
+  - family_name: Joongnajoche Medium OTF
+    type: Regular
+    preferred_family_name: Joongnajoche OTF
+    preferred_type: Medium
+    full_name: JoongnajocheStd-M
+    post_script_name: JoongnajocheStd-M
+    version: '1.0'
+    description: JoonggonaraFonts Opentype Package
+    copyright: "©Joonggonara Corp. All Rights Reserved."
+    font: 중나좋체 OTF Medium.otf
+extract: {}
+copyright: "©Joonggonara Corp. All Rights Reserved."
+command: create-formula https://go.aws/2u0lUvZ

--- a/Formulas/kinto_sans.yml
+++ b/Formulas/kinto_sans.yml
@@ -1,0 +1,257 @@
+---
+description: Kinto Sans
+homepage: https://github.com/ookamiinc/kinto
+resources:
+  Kinto_Sans.zip:
+    urls:
+    - https://github.com/ookamiinc/kinto/releases/download/v1.0.1/KintoSans.zip
+    sha256: 9a5033b789c90d27c89bdc36b4523aaff4a3f8856f24c0be17b1112cf756376f
+    file_size: 149161274
+fonts:
+- name: Kinto Sans
+  styles:
+  - family_name: Kinto Sans
+    type: Bold
+    full_name: KintoSans-Bold
+    post_script_name: KintoSans-Bold
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Bold.otf
+  - family_name: Kinto Sans
+    type: Bold
+    full_name: Kinto Sans Bold
+    post_script_name: KintoSans-Bold
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Bold.ttf
+  - family_name: Kinto Sans
+    type: Regular
+    full_name: KintoSans-Regular
+    post_script_name: KintoSans-Regular
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Regular.otf
+  - family_name: Kinto Sans
+    type: Regular
+    full_name: Kinto Sans Regular
+    post_script_name: KintoSans-Regular
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Regular.ttf
+- name: Kinto Sans Black
+  styles:
+  - family_name: Kinto Sans Black
+    type: Regular
+    preferred_family_name: Kinto Sans
+    preferred_type: Black
+    full_name: KintoSans-Black
+    post_script_name: KintoSans-Black
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Black.otf
+  - family_name: Kinto Sans Black
+    type: Regular
+    preferred_family_name: Kinto Sans
+    preferred_type: Black
+    full_name: Kinto Sans Black
+    post_script_name: KintoSans-Black
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Black.ttf
+- name: Kinto Sans Light
+  styles:
+  - family_name: Kinto Sans Light
+    type: Regular
+    preferred_family_name: Kinto Sans
+    preferred_type: Light
+    full_name: KintoSans-Light
+    post_script_name: KintoSans-Light
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Light.otf
+  - family_name: Kinto Sans Light
+    type: Regular
+    preferred_family_name: Kinto Sans
+    preferred_type: Light
+    full_name: Kinto Sans Light
+    post_script_name: KintoSans-Light
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Light.ttf
+- name: Kinto Sans Med
+  styles:
+  - family_name: Kinto Sans Med
+    type: Regular
+    preferred_family_name: Kinto Sans
+    preferred_type: Medium
+    full_name: KintoSans-Medium
+    post_script_name: KintoSans-Medium
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Medium.otf
+  - family_name: Kinto Sans Med
+    type: Regular
+    preferred_family_name: Kinto Sans
+    preferred_type: Medium
+    full_name: Kinto Sans Medium
+    post_script_name: KintoSans-Medium
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Medium.ttf
+- name: Kinto Sans Thin
+  styles:
+  - family_name: Kinto Sans Thin
+    type: Regular
+    preferred_family_name: Kinto Sans
+    preferred_type: Thin
+    full_name: KintoSans-Thin
+    post_script_name: KintoSans-Thin
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Thin.otf
+  - family_name: Kinto Sans Thin
+    type: Regular
+    preferred_family_name: Kinto Sans
+    preferred_type: Thin
+    full_name: Kinto Sans Thin
+    post_script_name: KintoSans-Thin
+    version: '0.001'
+    description: Kinto is a project maintained by Riomar Mccartney at ookami Inc.
+      The font family is a forked project from Google Fonts / Adobe and based on Noto
+      / Source Han font family. More information at https://github.com/ookamiinc/kinto
+    copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+    font: KintoSans-Thin.ttf
+extract: {}
+copyright: Copyright © 2019 The Kinto Project Authors at ookami Inc.
+license_url: http://scripts.sil.org/OFL
+open_license: |-
+  Copyright © 2019 The Kinto Project Authors at ookami Inc.
+  Copyright © 2014-2019 The Noto Project Authors (github.com/googlei18n/noto-fonts). Noto is a trademark of Google Inc.
+  Copyright © 2014-2019 Adobe Systems Incorporated (http://www.adobe.com/), with Reserved Font Name 'Source'. Source is a trademark of Adobe in the United States
+  and/or other countries.
+
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at:
+  http://scripts.sil.org/OFL
+
+  -----------------------------------------------------------
+  SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+  -----------------------------------------------------------
+
+  PREAMBLE
+  The goals of the Open Font License (OFL) are to stimulate worldwide
+  development of collaborative font projects, to support the font creation
+  efforts of academic and linguistic communities, and to provide a free and
+  open framework in which fonts may be shared and improved in partnership
+  with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and
+  redistributed freely as long as they are not sold by themselves. The
+  fonts, including any derivative works, can be bundled, embedded,
+  redistributed and/or sold with any software provided that any reserved
+  names are not used by derivative works. The fonts and derivatives,
+  however, cannot be released under any other type of license. The
+  requirement for fonts to remain under this license does not apply
+  to any document created using the fonts or their derivatives.
+
+  DEFINITIONS
+  "Font Software" refers to the set of files released by the Copyright
+  Holder(s) under this license and clearly marked as such. This may
+  include source files, build scripts and documentation.
+
+  "Reserved Font Name" refers to any names specified as such after the
+  copyright statement(s).
+
+  "Original Version" refers to the collection of Font Software components as
+  distributed by the Copyright Holder(s).
+
+  "Modified Version" refers to any derivative made by adding to, deleting,
+  or substituting -- in part or in whole -- any of the components of the
+  Original Version, by changing formats or by porting the Font Software to a
+  new environment.
+
+  "Author" refers to any designer, engineer, programmer, technical
+  writer or other person who contributed to the Font Software.
+
+  PERMISSION AND CONDITIONS
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of the Font Software, to use, study, copy, merge, embed, modify,
+  redistribute, and sell modified and unmodified copies of the Font
+  Software, subject to the following conditions:
+
+  1) Neither the Font Software nor any of its individual components,
+  in Original or Modified Versions, may be sold by itself.
+
+  2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+  3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the corresponding
+  Copyright Holder. This restriction only applies to the primary font name as
+  presented to the users.
+
+  4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+  5) The Font Software, modified or unmodified, in part or in whole,
+  must be distributed entirely under this license, and must not be
+  distributed under any other license. The requirement for fonts to
+  remain under this license does not apply to any document created
+  using the Font Software.
+
+  TERMINATION
+  This license becomes null and void if any of the above conditions are
+  not met.
+
+  DISCLAIMER
+  THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+  OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+  DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+  OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://github.com/ookamiinc/kinto/releases/download/v1.0.1/KintoSans.zip

--- a/Formulas/kodomorounded.yml
+++ b/Formulas/kodomorounded.yml
@@ -1,0 +1,39 @@
+---
+description: KodomoRounded
+homepage: https://fontopo.com/
+resources:
+  KodomoRounded.zip:
+    urls:
+    - https://fontopo.com/fontdata/kodomo.zip
+    sha256: fe0794c6c1b25cc683cf4a01d6acfc874f36e810b5b7f23cfd9fd75cbb70bda3
+    file_size: 948018
+fonts:
+- name: KodomoRounded
+  styles:
+  - family_name: KodomoRounded
+    type: Regular
+    preferred_family_name: KodomoRounded
+    preferred_type: Regular
+    full_name: KodomoRounded
+    post_script_name: KodomoRounded
+    version: '0.15'
+    copyright: Nakai Yoshihisa
+    font: KodomoRounded.otf
+- name: KodomoRounded-Light
+  styles:
+  - family_name: KodomoRounded-Light
+    type: Regular
+    preferred_family_name: KodomoRounded-Light
+    preferred_type: Regular
+    full_name: KodomoRounded-Light
+    post_script_name: KodomoRounded-Light
+    version: '1.01'
+    copyright: Nakai Yoshihisa
+    font: KodomoRounded-Light.otf
+extract: {}
+copyright: Nakai Yoshihisa
+command: create-formula https://fontopo.com/fontdata/kodomo.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  All fonts on this site can be downloaded and used for commercial purposes for
+  free.

--- a/Formulas/kokorominchoutai.yml
+++ b/Formulas/kokorominchoutai.yml
@@ -1,0 +1,68 @@
+---
+description: KokoroMinchoutai
+homepage: https://fontopo.com/
+resources:
+  KokoroMinchoutai.zip:
+    urls:
+    - https://fontopo.com/fontdata/kokoro.zip
+    sha256: d62c3de1fccce557fe94f5d39e1d0d5af3591a60cb432140b14b4b9d6460b490
+    file_size: 2524476
+fonts:
+- name: KokoroMinchoutai
+  styles:
+  - family_name: KokoroMinchoutai
+    type: Regular
+    preferred_family_name: KokoroMinchoutai
+    preferred_type: Regular
+    full_name: KokoroMinchoutai
+    post_script_name: KokoroMinchoutai
+    version: '1.00'
+    copyright: Typing Art
+    font: Kokoro.otf
+extract: {}
+copyright: Typing Art
+command: create-formula https://fontopo.com/fontdata/kokoro.zip
+license_url: https://fontopo.com/?page_id=55
+open_license: |
+  IPA FONT LICENSE AGREEMENT V1.0
+  The Licensor provides the Licensed Program (as defined in Article 1 below) under the terms of this license agreement (“Agreement”). Any use, reproduction or distribution of the Licensed Program, or any exercise of rights under this Agreement by a Recipient ( (as defined in Article 1 below) constitutes the Recipient's acceptance of this Agreement.
+  Article 1 (Definitions)
+  1. “Digital Font Program” shall mean a computer program containing, or used to render or display fonts.
+  2. “Licensed Program” shall mean a Digital Font Program licensed by the Licensor under this Agreement.
+  3. “Derived Program” shall mean a Digital Font Program created as a result of a modification, addition, deletion, replacement or any other adaptation to or of a part or all of the Licensed Program, and includes a case where a Digital Font Program newly created by retrieving font information from a part or all of the Licensed Program or Embedded Fonts from a Digital Document File with or without modification of the retrieved font information.
+  4. “Digital Content” shall mean products provided to end users in the form of digital data, including video content, motion and/or still pictures, TV programs or other broadcasting content and products consisting of character text, pictures, photographic images, graphic symbols and /or the like.
+  5. “Digital Document File” shall mean a PDF file or other Digital Content created by various software programs in which a part or all of the Licensed Program becomes embedded or contained in the file for the display of the font (“Embedded Fonts”). Fonts are used only in the display of characters in the particular Digital Document File within which they are embedded, and shall be distinguished from those in any Digital Font Program, which may be used for display of characters outside that particular Digital Document File.
+  6. “Computer” shall include a server in this Agreement.
+  7. “Reproduction and Other Exploitation” shall mean reproduction, transfer, distribution, lease, public transmission, presentation, exhibition, adaptation and any other exploitation.
+  8. “Recipient” shall mean anyone who receives the Licensed Program under this Agreement, including one that receives the Licensed Program from a Recipient.
+  Article 2 (Grant of License)
+  The Licensor grants to the Recipient a license to use the Licensed Program in any and all countries in accordance with each of the provisions set forth in this Agreement. no sense is this Agreement intended to transfer any right relating to the Licensed Program held by the Licensor except as specifically set forth herein or any right relating to any trademark, trade name, or service mark to the Recipient.
+  1. The Recipient may install the Licensed Program on any number of Computers and use the same in accordance with the provisions set forth in this Agreement.
+  2. The Recipient may use the Licensed Program, with or without modification in printed materials or in Digital Content as an expression of character texts or the like.
+  3. The Recipient may conduct Reproduction and Other Exploitation of the printed materials and Digital Content created in accordance with the preceding Paragraph, for commercial or non-commercial purposes and in any form of media including but not limited to broadcasting, communication and various recording media.
+  4. If any Recipient extracts Embedded Fonts from a Digital Document File to create a Derived Program, such Derived Program shall be subject to the terms of this agreement.
+  5. If any Recipient performs Reproduction or Other Exploitation of a Digital Document File in which Embedded Fonts of the Licensed Program are used only for rendering the Digital Content within such Digital Document File then such Recipient shall have no further obligations under this Agreement in relation to such actions .
+  6. The Recipient may reproduce the Licensed Program as is without modification and transfer such copies, publicly transmit or otherwise redistribute the Licensed Program to a third party for commercial or non-commercial purposes (“Redistribute”), in accordance with the provisions set forth in Article 3 Paragraph 2.
+  7. The Recipient may create, use, reproduce and/or Redistribute a Derived Program under the terms stated above for the Licensed Program: provided, that the Recipient shall follow the provisions set forth in Article 3 Paragraph 1 when Redistributing the Derived Program.
+  Article 3 (Restrictions)
+  The license granted in the preceding Article shall be subject to the following restrictions:
+  1. If a Derived Program is Redistributed pursuant to Paragraph 4 and 7 of the preceding Article, the following conditions must be met:
+     (1) The following must be also Redistributed together with the Derived Program, or be made available online or by means of mailing mechanisms in exchange for a cost which does not exceed the total costs of postage, storage medium and handling fees:
+         (a) a copy of the Derived Program; and
+         (b) any additional file created by the font developing program in the course of creating the Derived Program that can be used for further modification of the Derived Program, if any.
+     (2) It is required to also Redistribute means to enable recipients of the Derived Program to replace the Derived Program with the Licensed Program first released under this License (the “Original Program”). Original Program, or instructions setting out a method to replace the Derived Program with the Original Program.
+     (3) The Recipient must license the Derived Program under the terms and conditions of this Agreement.
+     (4) No one may use or include the name of the Licensed Program as a program name, font name or file name of the Derived Program.
+     (5) Any material to be made available online or by means of mailing a medium to satisfy the requirements of this paragraph may be provided, verbatim, by any party wishing to do so.
+  2. If the Recipient Redistributes the Licensed Program pursuant to Paragraph 6 of the preceding Article, the Recipient shall meet all of the following conditions:
+     (1) The Recipient may not change the name of the Licensed Program.
+     (2) The Recipient may not alter or otherwise modify the Licensed Program.
+     (3) The Recipient must attach a copy of this Agreement to the Licensed Program.
+  3. THIS LICENSED PROGRAM IS PROVIDED BY THE LICENSOR “AS IS” AND ANY EXPRESSED OR IMPLIED WARRANTY AS TO THE LICENSED PROGRAM OR ANY DERIVED PROGRAM, INCLUDING, BUT NOT LIMITED TO, WARRANTIES OF TITLE, NON-INFRINGEMENT, MERCHANTABILITY, OR FITNESS FOR A PARTICULAR PURPOSE, ARE DISCLAIMED. IN NO EVENT SHALL THE LICENSOR BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXTENDED, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO; PROCUREMENT OF SUBSTITUTED GOODS OR SERVICE; DAMAGES ARISING FROM SYSTEM FAILURE LOSS OR CORRUPTION OF EXISTING DATA OR PROGRAM; LOST PROFITS), HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE INSTALLATION, USE,THE REPRODUCTION OR OTHER EXPLOITATION OF THE LICENSED PROGRAM OR ANY DERIVED PROGRAM OR THE EXERCISE OF ANY RIGHTS GRANTED HEREUNDER, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+  4. The Licensor is under no obligation to respond to any technical questions or inquiries, or provide any other user support in connection with the installation, use or the Reproduction and Other Exploitation of the Licensed Program or Derived Programs thereof.
+  Article 4 (Termination of Agreement)
+  1. The term of this Agreement shall begin from the time of receipt of the Licensed Program by the Recipient and shall continue as long as the Recipient retains any such Licensed Program in any way.
+  2. Notwithstanding the provision set forth in the preceding Paragraph, in the event of the breach of any of the provisions set forth in this Agreement by the Recipient, this Agreement shall automatically terminate without any notice. use or conduct Reproduction and Other Exploitation of the Licensed Program or a Derived Program: provided that such termination shall not affect any rights of any other Recipient receiving the Licensed Program or the Derived Program from such Recipient who breached this Agreement.
+  Article 5 (Governing Law)
+  1. In such an event, the Recipient may select either this Agreement or any subsequent version of the Agreement in using, conducting the Reproduction and Other Exploitation of, or Redistributing the Licensed Program or a Derived Program. Other matters not specified above shall be subject to the Copyright Law of Japan and other related laws and regulations of Japan.
+  2. This Agreement shall be constructed under the laws of Japan.

--- a/Formulas/komorebi_gothic.yml
+++ b/Formulas/komorebi_gothic.yml
@@ -1,5 +1,6 @@
 ---
 description: komorebi gothic
+homepage: https://modi.jpn.org/
 resources:
   komorebi_gothic.zip:
     urls:
@@ -37,7 +38,9 @@ copyright: 'Author: HORAI Wataru. License: This font is a free software. Unlimit
   either commercially and noncommercially. THIS FONT IS PROVIDED "AS IS" WITHOUT WARRANTY.'
 command: create-formula https://modi.jpn.org/download/MODI_komorebi-gothic_2018_0501.zip
 license_url: https://modi.jpn.org/font_komorebi-gothic.php
-requires_license_agreement: |-
+open_license: |-
   Ume font is free (free) software.
 
-  Regardless of the presence or absence of any modification, and even for commercial use, you can freely use, reproduce, and redistribute them, but there is no guarantee for everything.
+  Regardless of the presence or absence of any modification, and even for
+  commercial use, you can freely use, reproduce, and redistribute them, but
+  there is no guarantee for everything.

--- a/Formulas/kurobara-cinderella.yml
+++ b/Formulas/kurobara-cinderella.yml
@@ -23,7 +23,7 @@ extract: {}
 copyright: Copyright(c) 2017 M+ FONTS PROJECT/MODI
 command: create-formula https://modi.jpn.org/download/MODI_kurobara-cinderella_2018_0805.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2017 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/kurobara_gothic.yml
+++ b/Formulas/kurobara_gothic.yml
@@ -89,7 +89,7 @@ extract: {}
 copyright: Copyright(c) 2017 M+ FONTS PROJECT/MODI
 command: create-formula https://modi.jpn.org/download/MODI_kurobara-gothic_2018_1102.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2017 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/manabiya.yml
+++ b/Formulas/manabiya.yml
@@ -1,5 +1,6 @@
 ---
 description: Manabiya
+homepage: https://modi.jpn.org/
 resources:
   Manabiya-.zip:
     urls:
@@ -33,7 +34,7 @@ extract: {}
 copyright: MODI
 command: create-formula https://modi.jpn.org/download/MODI_manabiya_2018_0314.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2018 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/martian_mono.yml
+++ b/Formulas/martian_mono.yml
@@ -1,0 +1,408 @@
+---
+description: Martian Mono
+homepage: https://evilmartians.com
+resources:
+  Martian_Mono.zip:
+    urls:
+    - https://github.com/evilmartians/mono/releases/download/v1.0.0/martian-mono-1.0.0-otf.zip
+    sha256: 82683f519651fb05e29d47d075f10e8db40ff5328a50e641e5c30f5fa94297b6
+    file_size: 892960
+fonts:
+- name: Martian Mono Cn Lt
+  styles:
+  - family_name: Martian Mono Cn Lt
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Cn Lt
+    full_name: Martian Mono Cn Lt
+    post_script_name: MartianMono-CnLt
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-CnLt.otf
+- name: Martian Mono Cn Md
+  styles:
+  - family_name: Martian Mono Cn Md
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Cn Md
+    full_name: Martian Mono Cn Md
+    post_script_name: MartianMono-CnMd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-CnMd.otf
+- name: Martian Mono Cn Rg
+  styles:
+  - family_name: Martian Mono Cn Rg
+    type: Bold
+    preferred_family_name: Martian Mono
+    preferred_type: Cn Bd
+    full_name: Martian Mono Cn Bd
+    post_script_name: MartianMono-CnBd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-CnBd.otf
+  - family_name: Martian Mono Cn Rg
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Cn Rg
+    full_name: Martian Mono Cn Rg
+    post_script_name: MartianMono-CnRg
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-CnRg.otf
+- name: Martian Mono Cn Th
+  styles:
+  - family_name: Martian Mono Cn Th
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Cn Th
+    full_name: Martian Mono Cn Th
+    post_script_name: MartianMono-CnTh
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-CnTh.otf
+- name: Martian Mono Cn xBd
+  styles:
+  - family_name: Martian Mono Cn xBd
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Cn xBd
+    full_name: Martian Mono Cn xBd
+    post_script_name: MartianMono-CnxBd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-CnxBd.otf
+- name: Martian Mono Cn xLt
+  styles:
+  - family_name: Martian Mono Cn xLt
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Cn xLt
+    full_name: Martian Mono Cn xLt
+    post_script_name: MartianMono-CnxLt
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-CnxLt.otf
+- name: Martian Mono Nr Lt
+  styles:
+  - family_name: Martian Mono Nr Lt
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Nr Lt
+    full_name: Martian Mono Nr Lt
+    post_script_name: MartianMono-NrLt
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-NrLt.otf
+- name: Martian Mono Nr Md
+  styles:
+  - family_name: Martian Mono Nr Md
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Nr Md
+    full_name: Martian Mono Nr Md
+    post_script_name: MartianMono-NrMd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-NrMd.otf
+- name: Martian Mono Nr Rg
+  styles:
+  - family_name: Martian Mono Nr Rg
+    type: Bold
+    preferred_family_name: Martian Mono
+    preferred_type: Nr Bd
+    full_name: Martian Mono Nr Bd
+    post_script_name: MartianMono-NrBd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-NrBd.otf
+  - family_name: Martian Mono Nr Rg
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Nr Rg
+    full_name: Martian Mono Nr Rg
+    post_script_name: MartianMono-NrRg
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-NrRg.otf
+- name: Martian Mono Nr Th
+  styles:
+  - family_name: Martian Mono Nr Th
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Nr Th
+    full_name: Martian Mono Nr Th
+    post_script_name: MartianMono-NrTh
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-NrTh.otf
+- name: Martian Mono Nr xBd
+  styles:
+  - family_name: Martian Mono Nr xBd
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Nr xBd
+    full_name: Martian Mono Nr xBd
+    post_script_name: MartianMono-NrxBd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-NrxBd.otf
+- name: Martian Mono Nr xLt
+  styles:
+  - family_name: Martian Mono Nr xLt
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Nr xLt
+    full_name: Martian Mono Nr xLt
+    post_script_name: MartianMono-NrxLt
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-NrxLt.otf
+- name: Martian Mono Std Lt
+  styles:
+  - family_name: Martian Mono Std Lt
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Std Lt
+    full_name: Martian Mono Std Lt
+    post_script_name: MartianMono-StdLt
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-StdLt.otf
+- name: Martian Mono Std Md
+  styles:
+  - family_name: Martian Mono Std Md
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Std Md
+    full_name: Martian Mono Std Md
+    post_script_name: MartianMono-StdMd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-StdMd.otf
+- name: Martian Mono Std Rg
+  styles:
+  - family_name: Martian Mono Std Rg
+    type: Bold
+    preferred_family_name: Martian Mono
+    preferred_type: Std Bd
+    full_name: Martian Mono Std Bd
+    post_script_name: MartianMono-StdBd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-StdBd.otf
+  - family_name: Martian Mono Std Rg
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Std Rg
+    full_name: Martian Mono Std Rg
+    post_script_name: MartianMono-StdRg
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-StdRg.otf
+- name: Martian Mono Std Th
+  styles:
+  - family_name: Martian Mono Std Th
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Std Th
+    full_name: Martian Mono Std Th
+    post_script_name: MartianMono-StdTh
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-StdTh.otf
+- name: Martian Mono Std xBd
+  styles:
+  - family_name: Martian Mono Std xBd
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Std xBd
+    full_name: Martian Mono Std xBd
+    post_script_name: MartianMono-StdxBd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-StdxBd.otf
+- name: Martian Mono Std xLt
+  styles:
+  - family_name: Martian Mono Std xLt
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: Std xLt
+    full_name: Martian Mono Std xLt
+    post_script_name: MartianMono-StdxLt
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-StdxLt.otf
+- name: Martian Mono sWd Lt
+  styles:
+  - family_name: Martian Mono sWd Lt
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: sWd Lt
+    full_name: Martian Mono sWd Lt
+    post_script_name: MartianMono-sWdLt
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-sWdLt.otf
+- name: Martian Mono sWd Md
+  styles:
+  - family_name: Martian Mono sWd Md
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: sWd Md
+    full_name: Martian Mono sWd Md
+    post_script_name: MartianMono-sWdMd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-sWdMd.otf
+- name: Martian Mono sWd Rg
+  styles:
+  - family_name: Martian Mono sWd Rg
+    type: Bold
+    preferred_family_name: Martian Mono
+    preferred_type: sWd Bd
+    full_name: Martian Mono sWd Bd
+    post_script_name: MartianMono-sWdBd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-sWdBd.otf
+  - family_name: Martian Mono sWd Rg
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: sWd Rg
+    full_name: Martian Mono sWd Rg
+    post_script_name: MartianMono-sWdRg
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-sWdRg.otf
+- name: Martian Mono sWd Th
+  styles:
+  - family_name: Martian Mono sWd Th
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: sWd Th
+    full_name: Martian Mono sWd Th
+    post_script_name: MartianMono-sWdTh
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-sWdTh.otf
+- name: Martian Mono sWd xBd
+  styles:
+  - family_name: Martian Mono sWd xBd
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: sWd xBd
+    full_name: Martian Mono sWd xBd
+    post_script_name: MartianMono-sWdxBd
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-sWdxBd.otf
+- name: Martian Mono sWd xLt
+  styles:
+  - family_name: Martian Mono sWd xLt
+    type: Regular
+    preferred_family_name: Martian Mono
+    preferred_type: sWd xLt
+    full_name: Martian Mono sWd xLt
+    post_script_name: MartianMono-sWdxLt
+    version: '1.000'
+    copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+    font: MartianMono-sWdxLt.otf
+extract: {}
+copyright: Copyright 2020 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+license_url: https://scripts.sil.org/OFL
+command: create-formula https://github.com/evilmartians/mono/releases/download/v1.0.0/martian-mono-1.0.0-otf.zip
+open_license: |
+  Copyright 2021 The Martian Mono Project Authors (https://github.com/evilmartians/mono)
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at:
+  http://scripts.sil.org/OFL
+
+
+  -----------------------------------------------------------
+  SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+  -----------------------------------------------------------
+
+  PREAMBLE
+  The goals of the Open Font License (OFL) are to stimulate worldwide
+  development of collaborative font projects, to support the font creation
+  efforts of academic and linguistic communities, and to provide a free and
+  open framework in which fonts may be shared and improved in partnership
+  with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and
+  redistributed freely as long as they are not sold by themselves. The
+  fonts, including any derivative works, can be bundled, embedded,
+  redistributed and/or sold with any software provided that any reserved
+  names are not used by derivative works. The fonts and derivatives,
+  however, cannot be released under any other type of license. The
+  requirement for fonts to remain under this license does not apply
+  to any document created using the fonts or their derivatives.
+
+  DEFINITIONS
+  "Font Software" refers to the set of files released by the Copyright
+  Holder(s) under this license and clearly marked as such. This may
+  include source files, build scripts and documentation.
+
+  "Reserved Font Name" refers to any names specified as such after the
+  copyright statement(s).
+
+  "Original Version" refers to the collection of Font Software components as
+  distributed by the Copyright Holder(s).
+
+  "Modified Version" refers to any derivative made by adding to, deleting,
+  or substituting -- in part or in whole -- any of the components of the
+  Original Version, by changing formats or by porting the Font Software to a
+  new environment.
+
+  "Author" refers to any designer, engineer, programmer, technical
+  writer or other person who contributed to the Font Software.
+
+  PERMISSION & CONDITIONS
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of the Font Software, to use, study, copy, merge, embed, modify,
+  redistribute, and sell modified and unmodified copies of the Font
+  Software, subject to the following conditions:
+
+  1) Neither the Font Software nor any of its individual components,
+  in Original or Modified Versions, may be sold by itself.
+
+  2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+  3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the corresponding
+  Copyright Holder. This restriction only applies to the primary font name as
+  presented to the users.
+
+  4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+  5) The Font Software, modified or unmodified, in part or in whole,
+  must be distributed entirely under this license, and must not be
+  distributed under any other license. The requirement for fonts to
+  remain under this license does not apply to any document created
+  using the Font Software.
+
+  TERMINATION
+  This license becomes null and void if any of the above conditions are
+  not met.
+
+  DISCLAIMER
+  THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+  OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+  DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+  OTHER DEALINGS IN THE FONT SOFTWARE.

--- a/Formulas/memoir.yml
+++ b/Formulas/memoir.yml
@@ -1,5 +1,6 @@
 ---
 description: Memoir
+homepage: https://modi.jpn.org/
 resources:
   Memoir.zip:
     urls:
@@ -44,7 +45,7 @@ extract: {}
 copyright: MODI
 command: create-formula https://modi.jpn.org/download/MODI_memoir_2018_1215.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2018 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/mitimasu.yml
+++ b/Formulas/mitimasu.yml
@@ -1,0 +1,44 @@
+---
+description: Mitimasu
+resources:
+  Mitimasu.zip:
+    urls:
+    - http://www.masuseki.com/works/mitimasu.zip
+    sha256: 27ed584743cc8418335aa4272b41b468645436e0f9c212677dbca9f44d4a2fa7
+    file_size: 3367690
+fonts:
+- name: Mitimasu
+  styles:
+  - family_name: Mitimasu
+    type: Regular
+    full_name: Mitimasu
+    post_script_name: Mitimasu
+    version: '2.00'
+    copyright: MASUDA mitiya
+    font: mitimasu.ttf
+extract: {}
+copyright: MASUDA mitiya
+command: create-formula http://www.masuseki.com/works/mitimasu.zip
+license_url: http://www.masuseki.com/wp/?p=197
+requires_license_agreement: |-
+  Copyright 2013 桝田道也 (Michiya Masuda)
+
+  MIT License
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the “Software”), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in all
+  copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+  SOFTWARE.

--- a/Formulas/mochiy_pop_one_otf_extrabold.yml
+++ b/Formulas/mochiy_pop_one_otf_extrabold.yml
@@ -1,0 +1,132 @@
+---
+description: Mochiy Pop One OTF ExtraBold
+homepage: http://fontdasu.com
+resources:
+  Mochiy_Pop_One_OTF_ExtraBold.zip:
+    urls:
+    - https://fontdasu.com/mochiypop-download/
+    sha256: 9ee7f4570f7617827a8549cc893c8046f6c7e6f092355bd7da5e9d75498086fc
+    file_size: 3802615
+fonts:
+- name: Mochiy Pop One OTF ExtraBold
+  styles:
+  - family_name: Mochiy Pop One OTF ExtraBold
+    type: Regular
+    preferred_family_name: Mochiy Pop One OTF
+    preferred_type: ExtraBold
+    full_name: Mochiy Pop One OTF ExtraBold
+    post_script_name: MochiyPopOne-OTF-ExtraBold
+    version: 2.000;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2020 The MochiyPop Project Authors (https://github.com/fontdasu/Mochiypop)
+    font: MochiyPopOne-OTF-ExtraBold.otf
+extract: {}
+copyright: Copyright 2020 The MochiyPop Project Authors (https://github.com/fontdasu/Mochiypop)
+license_url: https://scripts.sil.org/OFL
+open_license: |-
+  Copyright 2020 The Mochiypop Project Authors (https://github.com/fontdasu/Mochiypop)
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at:
+  https://scripts.sil.org/OFL
+
+
+  SIL Open Font License v1.1
+  ====================================================
+
+
+  Preamble
+  ----------
+
+  The goals of the Open Font License (OFL) are to stimulate worldwide
+  development of collaborative font projects, to support the font creation
+  efforts of academic and linguistic communities, and to provide a free and
+  open framework in which fonts may be shared and improved in partnership
+  with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and
+  redistributed freely as long as they are not sold by themselves. The
+  fonts, including any derivative works, can be bundled, embedded,
+  redistributed and/or sold with any software provided that any reserved
+  names are not used by derivative works. The fonts and derivatives,
+  however, cannot be released under any other type of license. The
+  requirement for fonts to remain under this license does not apply
+  to any document created using the fonts or their derivatives.
+
+
+  Definitions
+  -------------
+
+  `"Font Software"` refers to the set of files released by the Copyright
+  Holder(s) under this license and clearly marked as such. This may
+  include source files, build scripts and documentation.
+
+  `"Reserved Font Name"` refers to any names specified as such after the
+  copyright statement(s).
+
+  `"Original Version"` refers to the collection of Font Software components as
+  distributed by the Copyright Holder(s).
+
+  `"Modified Version"` refers to any derivative made by adding to, deleting,
+  or substituting -- in part or in whole -- any of the components of the
+  Original Version, by changing formats or by porting the Font Software to a
+  new environment.
+
+  `"Author"` refers to any designer, engineer, programmer, technical
+  writer or other person who contributed to the Font Software.
+
+
+  Permission & Conditions
+  ------------------------
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of the Font Software, to use, study, copy, merge, embed, modify,
+  redistribute, and sell modified and unmodified copies of the Font
+  Software, subject to the following conditions:
+
+  1. Neither the Font Software nor any of its individual components,
+     in Original or Modified Versions, may be sold by itself.
+
+  2. Original or Modified Versions of the Font Software may be bundled,
+     redistributed and/or sold with any software, provided that each copy
+     contains the above copyright notice and this license. These can be
+     included either as stand-alone text files, human-readable headers or
+     in the appropriate machine-readable metadata fields within text or
+     binary files as long as those fields can be easily viewed by the user.
+
+  3. No Modified Version of the Font Software may use the Reserved Font
+     Name(s) unless explicit written permission is granted by the corresponding
+     Copyright Holder. This restriction only applies to the primary font name as
+     presented to the users.
+
+  4. The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+     Software shall not be used to promote, endorse or advertise any
+     Modified Version, except to acknowledge the contribution(s) of the
+     Copyright Holder(s) and the Author(s) or with their explicit written
+     permission.
+
+  5. The Font Software, modified or unmodified, in part or in whole,
+     must be distributed entirely under this license, and must not be
+     distributed under any other license. The requirement for fonts to
+     remain under this license does not apply to any document created
+     using the Font Software.
+
+
+  Termination
+  -----------
+
+  This license becomes null and void if any of the above conditions are
+  not met.
+
+
+      DISCLAIMER
+
+      THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+      OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+      COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+      INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+      DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+      FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+      OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://fontdasu.com/mochiypop-download/

--- a/Formulas/mushin.yml
+++ b/Formulas/mushin.yml
@@ -1,5 +1,6 @@
 ---
 description: Mushin
+homepage: https://modi.jpn.org/
 resources:
   Mushin.zip:
     urls:
@@ -22,7 +23,7 @@ extract: {}
 copyright: MODI
 command: create-formula https://modi.jpn.org/download/MODI_mushin_2021_1104.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2016 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/mutsuki.yml
+++ b/Formulas/mutsuki.yml
@@ -1,0 +1,36 @@
+---
+description: Mutsuki
+homepage: https://mandel59.github.io/mutsuki/
+resources:
+  Mutsuki.zip:
+    urls:
+    - https://github.com/mandel59/mutsuki/releases/download/v19.232/Mutsuki.ttf.zip
+    sha256: f4762e790ea99127224c3351de72391138ef3e3a8e645f7676819f4cd08364d4
+    file_size: 310872
+fonts:
+- name: Mutsuki
+  styles:
+  - family_name: Mutsuki
+    type: Regular
+    preferred_family_name: Mutsuki
+    preferred_type: Medium
+    full_name: Mutsuki
+    post_script_name: Mutsuki
+    version: '19.232'
+    copyright: Copyright (c) 2008-2011 Gutenberg Labo.
+    font: Mutsuki.ttf
+extract: {}
+copyright: Copyright (c) 2008-2011 Gutenberg Labo. Copyright (c) 2012 Ryusei Yamaguchi.
+command: create-formula https://github.com/mandel59/mutsuki/releases/download/v19.232/Mutsuki.ttf.zip
+open_license: |
+  Copyright (c) 2008-2011 Gutenberg Labo.
+  Copyright (c) 2012 Ryusei Yamaguchi.
+
+  -
+
+  LICENSE
+
+  This font is free software.
+  Unlimited permission is granted to use, copy, and distribute it, with
+  or without modification, either commercially and noncommercially.
+  THESE FONTS ARE PROVIDED "AS IS" WITHOUT WARRANTY.

--- a/Formulas/mutsuki_kana.yml
+++ b/Formulas/mutsuki_kana.yml
@@ -1,0 +1,36 @@
+---
+description: Mutsuki Kana
+homepage: https://mandel59.github.io/mutsuki/
+resources:
+  Mutsuki_Kana.zip:
+    urls:
+    - https://github.com/mandel59/mutsuki/releases/download/v19.232/Mutsuki-kana.ttf.zip
+    sha256: aa706529c0e9774584d75c789d2d1d749f4eeec92f7b6552740075303ff8b7ea
+    file_size: 24744
+fonts:
+- name: Mutsuki Kana
+  styles:
+  - family_name: Mutsuki Kana
+    type: Regular
+    preferred_family_name: Mutsuki Kana
+    preferred_type: Medium
+    full_name: Mutsuki Kana
+    post_script_name: Mutsuki Kana
+    version: '19.232'
+    copyright: Copyright (c) 2008-2011 Gutenberg Labo.
+    font: Mutsuki-kana.ttf
+extract: {}
+copyright: Copyright (c) 2008-2011 Gutenberg Labo. Copyright (c) 2012 Ryusei Yamaguchi.
+command: create-formula https://github.com/mandel59/mutsuki/releases/download/v19.232/Mutsuki-kana.ttf.zip
+open_license: |
+  Copyright (c) 2008-2011 Gutenberg Labo.
+  Copyright (c) 2012 Ryusei Yamaguchi.
+
+  -
+
+  LICENSE
+
+  This font is free software.
+  Unlimited permission is granted to use, copy, and distribute it, with
+  or without modification, either commercially and noncommercially.
+  THESE FONTS ARE PROVIDED "AS IS" WITHOUT WARRANTY.

--- a/Formulas/oradano_mincho_gsrr.yml
+++ b/Formulas/oradano_mincho_gsrr.yml
@@ -1,0 +1,22 @@
+---
+description: Oradano Mincho GSRR
+homepage: http://www.asahi-net.or.jp/~sd5a-ucd/freefonts/Oradano-Mincho/
+resources:
+  Oradano-mincho-GSRR_mincho-GSRR.zip:
+    urls:
+    - http://www.asahi-net.or.jp/~sd5a-ucd/freefonts/Oradano-Mincho/OradanoGSRR2018.zip
+    sha256: 6981a562be950808b317f6a2acf65fa65bfe970192070c88024e5b46a9ef71a3
+    file_size: 7220297
+fonts:
+- name: Oradano-mincho-GSRR
+  styles:
+  - family_name: Oradano-mincho-GSRR
+    type: mincho-GSRR
+    full_name: Oradano-mincho-GSRR
+    post_script_name: Oradano-mincho-GSRR
+    version: 0.2018.0101
+    copyright: Public Domain
+    font: OradanoGSRR.ttf
+extract: {}
+copyright: Public Domain
+command: create-formula http://www.asahi-net.or.jp/\~sd5a-ucd/freefonts/Oradano-Mincho/OradanoGSRR2018.zip

--- a/Formulas/senobi_gothic.yml
+++ b/Formulas/senobi_gothic.yml
@@ -45,7 +45,7 @@ extract: {}
 copyright: Copyright(c) 2016 M+ FONTS PROJECT/MODI
 command: create-formula https://modi.jpn.org/download/MODI_Senobi-Gothic_2017_0702.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2016 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/shiasatte_bold.yml
+++ b/Formulas/shiasatte_bold.yml
@@ -1,5 +1,6 @@
 ---
 description: SHIASATTE Bold
+homepage: https://modi.jpn.org/
 resources:
   SHIASATTE_Bold.zip:
     urls:
@@ -22,7 +23,7 @@ extract: {}
 copyright: MODI
 command: create-formula https://modi.jpn.org/download/MODI_shiasatte_2017_0527.zip
 license_url: https://modi.jpn.org/licence.php
-requires_license_agreement: |-
+open_license: |-
   Copyright (c) 2017 M+ FONTS PROJECT/MODI
 
   This Font Software is licensed under the SIL Open Font License, Version 1.1.

--- a/Formulas/shippori_antique.yml
+++ b/Formulas/shippori_antique.yml
@@ -1,0 +1,143 @@
+---
+description: Shippori Antique
+homepage: http://fontdasu.com
+resources:
+  Shippori_Antique.zip:
+    urls:
+    - https://fontdasu.com/shippori-antique-download/
+    sha256: c9edaa130272585f0c6801b06be32f9ea53d45659442a8c4fe09d8118566d081
+    file_size: 10054934
+fonts:
+- name: Shippori Antique B1 OTF Medium
+  styles:
+  - family_name: Shippori Antique B1 OTF Medium
+    type: Regular
+    preferred_family_name: Shippori Antique B1 OTF
+    preferred_type: Medium
+    full_name: Shippori Antique B1 OTF Medium
+    post_script_name: ShipporiAntiqueB1-OTF-Medium
+    version: 2.100;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2020 The Shippori Antique Project Authors (https://github.com/fontdasu/ShipporiAntique)
+    font: ShipporiAntiqueB1-OTF-Medium.otf
+- name: Shippori Antique OTF Medium
+  styles:
+  - family_name: Shippori Antique OTF Medium
+    type: Regular
+    preferred_family_name: Shippori Antique OTF
+    preferred_type: Medium
+    full_name: Shippori Antique OTF Medium
+    post_script_name: ShipporiAntique-OTF-Medium
+    version: 2.100;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2020 The Shippori Antique Project Authors (https://github.com/fontdasu/ShipporiAntique)
+    font: ShipporiAntique-OTF-Medium.otf
+extract: {}
+copyright: Copyright 2020 The Shippori Antique Project Authors (https://github.com/fontdasu/ShipporiAntique)
+license_url: https://scripts.sil.org/OFL
+open_license: |-
+  Copyright 2020 The Mochiypop Project Authors (https://github.com/fontdasu/Mochiypop)
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at:
+  https://scripts.sil.org/OFL
+
+
+  SIL Open Font License v1.1
+  ====================================================
+
+
+  Preamble
+  ----------
+
+  The goals of the Open Font License (OFL) are to stimulate worldwide
+  development of collaborative font projects, to support the font creation
+  efforts of academic and linguistic communities, and to provide a free and
+  open framework in which fonts may be shared and improved in partnership
+  with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and
+  redistributed freely as long as they are not sold by themselves. The
+  fonts, including any derivative works, can be bundled, embedded,
+  redistributed and/or sold with any software provided that any reserved
+  names are not used by derivative works. The fonts and derivatives,
+  however, cannot be released under any other type of license. The
+  requirement for fonts to remain under this license does not apply
+  to any document created using the fonts or their derivatives.
+
+
+  Definitions
+  -------------
+
+  `"Font Software"` refers to the set of files released by the Copyright
+  Holder(s) under this license and clearly marked as such. This may
+  include source files, build scripts and documentation.
+
+  `"Reserved Font Name"` refers to any names specified as such after the
+  copyright statement(s).
+
+  `"Original Version"` refers to the collection of Font Software components as
+  distributed by the Copyright Holder(s).
+
+  `"Modified Version"` refers to any derivative made by adding to, deleting,
+  or substituting -- in part or in whole -- any of the components of the
+  Original Version, by changing formats or by porting the Font Software to a
+  new environment.
+
+  `"Author"` refers to any designer, engineer, programmer, technical
+  writer or other person who contributed to the Font Software.
+
+
+  Permission & Conditions
+  ------------------------
+
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of the Font Software, to use, study, copy, merge, embed, modify,
+  redistribute, and sell modified and unmodified copies of the Font
+  Software, subject to the following conditions:
+
+  1. Neither the Font Software nor any of its individual components,
+     in Original or Modified Versions, may be sold by itself.
+
+  2. Original or Modified Versions of the Font Software may be bundled,
+     redistributed and/or sold with any software, provided that each copy
+     contains the above copyright notice and this license. These can be
+     included either as stand-alone text files, human-readable headers or
+     in the appropriate machine-readable metadata fields within text or
+     binary files as long as those fields can be easily viewed by the user.
+
+  3. No Modified Version of the Font Software may use the Reserved Font
+     Name(s) unless explicit written permission is granted by the corresponding
+     Copyright Holder. This restriction only applies to the primary font name as
+     presented to the users.
+
+  4. The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+     Software shall not be used to promote, endorse or advertise any
+     Modified Version, except to acknowledge the contribution(s) of the
+     Copyright Holder(s) and the Author(s) or with their explicit written
+     permission.
+
+  5. The Font Software, modified or unmodified, in part or in whole,
+     must be distributed entirely under this license, and must not be
+     distributed under any other license. The requirement for fonts to
+     remain under this license does not apply to any document created
+     using the Font Software.
+
+
+  Termination
+  -----------
+
+  This license becomes null and void if any of the above conditions are
+  not met.
+
+
+      DISCLAIMER
+
+      THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+      EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+      MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+      OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+      COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+      INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+      DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+      FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+      OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://fontdasu.com/shippori-antique-download/

--- a/Formulas/shippori_mincho.yml
+++ b/Formulas/shippori_mincho.yml
@@ -1,0 +1,208 @@
+---
+description: Shippori Mincho
+homepage: http://fontdasu.com
+resources:
+  Shippori_Mincho.zip:
+    urls:
+    - https://fontdasu.com/download/shippori3.zip
+    sha256: dbdcab920d82238bda26296bccd9630906b427ee91b31f5da2dde8e47b0b202e
+    file_size: 59496028
+fonts:
+- name: Shippori Mincho B1 OTF
+  styles:
+  - family_name: Shippori Mincho B1 OTF
+    type: Bold
+    full_name: Shippori Mincho B1 OTF Bold
+    post_script_name: ShipporiMinchoB1-OTF-Bold
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMinchoB1-OTF-Bold.otf
+- name: Shippori Mincho B1 OTF ExBold
+  styles:
+  - family_name: Shippori Mincho B1 OTF ExBold
+    type: Regular
+    preferred_family_name: Shippori Mincho B1 OTF
+    preferred_type: ExtraBold
+    full_name: Shippori Mincho B1 OTF ExBold
+    post_script_name: ShipporiMinchoB1-OTF-ExtraBold
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMinchoB1-OTF-ExtraBold.otf
+- name: Shippori Mincho B1 OTF Medium
+  styles:
+  - family_name: Shippori Mincho B1 OTF Medium
+    type: Regular
+    preferred_family_name: Shippori Mincho B1 OTF
+    preferred_type: Medium
+    full_name: Shippori Mincho B1 OTF Medium
+    post_script_name: ShipporiMinchoB1-OTF-Medium
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMinchoB1-OTF-Medium.otf
+- name: Shippori Mincho B1 OTF SemiBold
+  styles:
+  - family_name: Shippori Mincho B1 OTF SemiBold
+    type: Regular
+    preferred_family_name: Shippori Mincho B1 OTF
+    preferred_type: SemiBold
+    full_name: Shippori Mincho B1 OTF SemiBold
+    post_script_name: ShipporiMinchoB1-OTF-SemiBold
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMinchoB1-OTF-SemiBold.otf
+- name: Shippori Mincho B1 OTTF
+  styles:
+  - family_name: Shippori Mincho B1 OTTF
+    type: Regular
+    full_name: Shippori Mincho B1 OTTF
+    post_script_name: ShipporiMinchoB1-OTF-Regular
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMinchoB1-OTF-Regular.otf
+- name: Shippori Mincho OTF
+  styles:
+  - family_name: Shippori Mincho OTF
+    type: Bold
+    full_name: Shippori Mincho OTF Bold
+    post_script_name: ShipporiMincho-OTF-Bold
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMincho-OTF-Bold.otf
+  - family_name: Shippori Mincho OTF
+    type: Regular
+    full_name: Shippori Mincho OTF
+    post_script_name: ShipporiMincho-OTF-Regular
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMincho-OTF-Regular.otf
+- name: Shippori Mincho OTF ExtraBold
+  styles:
+  - family_name: Shippori Mincho OTF ExtraBold
+    type: Regular
+    preferred_family_name: Shippori Mincho OTF
+    preferred_type: ExtraBold
+    full_name: Shippori Mincho OTF ExtraBold
+    post_script_name: ShipporiMincho-OTF-ExtraBold
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMincho-OTF-ExtraBold.otf
+- name: Shippori Mincho OTF Medium
+  styles:
+  - family_name: Shippori Mincho OTF Medium
+    type: Regular
+    preferred_family_name: Shippori Mincho OTF
+    preferred_type: Medium
+    full_name: Shippori Mincho OTF Medium
+    post_script_name: ShipporiMincho-OTF-Medium
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMincho-OTF-Medium.otf
+- name: Shippori Mincho OTF SemiBold
+  styles:
+  - family_name: Shippori Mincho OTF SemiBold
+    type: Regular
+    preferred_family_name: Shippori Mincho OTF
+    preferred_type: SemiBold
+    full_name: Shippori Mincho OTF SemiBold
+    post_script_name: ShipporiMincho-OTF-SemiBold
+    version: 3.300;hotconv 1.0.109;makeotfexe 2.5.65596
+    copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+    font: ShipporiMincho-OTF-SemiBold.otf
+extract: {}
+copyright: Copyright 2021 The Shippori Min Project Authors (https://github.com/fontdasu/ShipporiMincho)
+license_url: https://scripts.sil.org/OFL
+open_license: |-
+  Copyright (c) 2021, The Shippori Mincho Project Authors (https://github.com/fontdasu/ShipporiMincho),
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at:
+  http://scripts.sil.org/OFL
+
+
+  -----------------------------------------------------------
+  SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+  -----------------------------------------------------------
+
+  PREAMBLE
+  The goals of the Open Font License (OFL) are to stimulate worldwide
+  development of collaborative font projects, to support the font creation
+  efforts of academic and linguistic communities, and to provide a free and
+  open framework in which fonts may be shared and improved in partnership
+  with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and
+  redistributed freely as long as they are not sold by themselves. The
+  fonts, including any derivative works, can be bundled, embedded,
+  redistributed and/or sold with any software provided that any reserved
+  names are not used by derivative works. The fonts and derivatives,
+  however, cannot be released under any other type of license. The
+  requirement for fonts to remain under this license does not apply
+  to any document created using the fonts or their derivatives.
+
+  DEFINITIONS
+  "Font Software" refers to the set of files released by the Copyright
+  Holder(s) under this license and clearly marked as such. This may
+  include source files, build scripts and documentation.
+
+  "Reserved Font Name" refers to any names specified as such after the
+  copyright statement(s).
+
+  "Original Version" refers to the collection of Font Software components as
+  distributed by the Copyright Holder(s).
+
+  "Modified Version" refers to any derivative made by adding to, deleting,
+  or substituting -- in part or in whole -- any of the components of the
+  Original Version, by changing formats or by porting the Font Software to a
+  new environment.
+
+  "Author" refers to any designer, engineer, programmer, technical
+  writer or other person who contributed to the Font Software.
+
+  PERMISSION & CONDITIONS
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of the Font Software, to use, study, copy, merge, embed, modify,
+  redistribute, and sell modified and unmodified copies of the Font
+  Software, subject to the following conditions:
+
+  1) Neither the Font Software nor any of its individual components,
+  in Original or Modified Versions, may be sold by itself.
+
+  2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+  3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the corresponding
+  Copyright Holder. This restriction only applies to the primary font name as
+  presented to the users.
+
+  4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+  5) The Font Software, modified or unmodified, in part or in whole,
+  must be distributed entirely under this license, and must not be
+  distributed under any other license. The requirement for fonts to
+  remain under this license does not apply to any document created
+  using the Font Software.
+
+  TERMINATION
+  This license becomes null and void if any of the above conditions are
+  not met.
+
+  DISCLAIMER
+  THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+  OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+  DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+  OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://fontdasu.com/download/shippori3.zip

--- a/Formulas/space_grotesk.yml
+++ b/Formulas/space_grotesk.yml
@@ -1,0 +1,187 @@
+---
+description: Space Grotesk
+homepage: https://fonts.floriankarsten.com
+resources:
+  Space_Grotesk.zip:
+    urls:
+    - https://github.com/floriankarsten/space-grotesk/releases/download/2.0.0/SpaceGrotesk-2.0.0.zip
+    sha256: 53b415577d4139248555300710bea0d268c7a5be67b93de53b716a9736cabffd
+    file_size: 697233
+fonts:
+- name: Space Grotesk
+  styles:
+  - family_name: Space Grotesk
+    type: Bold
+    full_name: Space Grotesk Bold
+    post_script_name: SpaceGrotesk-Bold
+    version: '2.000'
+    copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+    font: SpaceGrotesk-Bold.otf
+  - family_name: Space Grotesk
+    type: Bold
+    full_name: Space Grotesk Bold
+    post_script_name: SpaceGrotesk-Bold
+    version: 2.000; ttfautohint (v1.8.3)
+    copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+    font: SpaceGrotesk-Bold.ttf
+  - family_name: Space Grotesk
+    type: Regular
+    full_name: Space Grotesk Regular
+    post_script_name: SpaceGrotesk-Regular
+    version: '2.000'
+    copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+    font: SpaceGrotesk-Regular.otf
+  - family_name: Space Grotesk
+    type: Regular
+    full_name: Space Grotesk Regular
+    post_script_name: SpaceGrotesk-Regular
+    version: 2.000; ttfautohint (v1.8.3)
+    copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+    font: SpaceGrotesk-Regular.ttf
+- name: Space Grotesk Light
+  styles:
+  - family_name: Space Grotesk Light
+    type: Regular
+    preferred_family_name: Space Grotesk
+    preferred_type: Light
+    full_name: Space Grotesk Light
+    post_script_name: SpaceGrotesk-Light
+    version: '2.000'
+    copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+    font: SpaceGrotesk-Light.otf
+  - family_name: Space Grotesk Light
+    type: Regular
+    preferred_family_name: Space Grotesk
+    preferred_type: Light
+    full_name: Space Grotesk Light
+    post_script_name: SpaceGrotesk-Light
+    version: '2.000'
+    copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+    font: SpaceGrotesk[wght].ttf
+  - family_name: Space Grotesk Light
+    type: Regular
+    preferred_family_name: Space Grotesk
+    preferred_type: Light
+    full_name: Space Grotesk Light
+    post_script_name: SpaceGrotesk-Light
+    version: 2.000; ttfautohint (v1.8.3)
+    copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+    font: SpaceGrotesk-Light.ttf
+- name: Space Grotesk Medium
+  styles:
+  - family_name: Space Grotesk Medium
+    type: Regular
+    preferred_family_name: Space Grotesk
+    preferred_type: Medium
+    full_name: Space Grotesk Medium
+    post_script_name: SpaceGrotesk-Medium
+    version: '2.000'
+    copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+    font: SpaceGrotesk-Medium.otf
+  - family_name: Space Grotesk Medium
+    type: Regular
+    preferred_family_name: Space Grotesk
+    preferred_type: Medium
+    full_name: Space Grotesk Medium
+    post_script_name: SpaceGrotesk-Medium
+    version: 2.000; ttfautohint (v1.8.3)
+    copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+    font: SpaceGrotesk-Medium.ttf
+extract: {}
+copyright: Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+license_url: https://scripts.sil.org/OFL
+open_license: |-
+  Copyright 2020 The Space Grotesk Project Authors (https://github.com/floriankarsten/space-grotesk)
+
+  This Font Software is licensed under the SIL Open Font License, Version 1.1.
+  This license is copied below, and is also available with a FAQ at:
+  http://scripts.sil.org/OFL
+
+
+  -----------------------------------------------------------
+  SIL OPEN FONT LICENSE Version 1.1 - 26 February 2007
+  -----------------------------------------------------------
+
+  PREAMBLE
+  The goals of the Open Font License (OFL) are to stimulate worldwide
+  development of collaborative font projects, to support the font creation
+  efforts of academic and linguistic communities, and to provide a free and
+  open framework in which fonts may be shared and improved in partnership
+  with others.
+
+  The OFL allows the licensed fonts to be used, studied, modified and
+  redistributed freely as long as they are not sold by themselves. The
+  fonts, including any derivative works, can be bundled, embedded,
+  redistributed and/or sold with any software provided that any reserved
+  names are not used by derivative works. The fonts and derivatives,
+  however, cannot be released under any other type of license. The
+  requirement for fonts to remain under this license does not apply
+  to any document created using the fonts or their derivatives.
+
+  DEFINITIONS
+  "Font Software" refers to the set of files released by the Copyright
+  Holder(s) under this license and clearly marked as such. This may
+  include source files, build scripts and documentation.
+
+  "Reserved Font Name" refers to any names specified as such after the
+  copyright statement(s).
+
+  "Original Version" refers to the collection of Font Software components as
+  distributed by the Copyright Holder(s).
+
+  "Modified Version" refers to any derivative made by adding to, deleting,
+  or substituting -- in part or in whole -- any of the components of the
+  Original Version, by changing formats or by porting the Font Software to a
+  new environment.
+
+  "Author" refers to any designer, engineer, programmer, technical
+  writer or other person who contributed to the Font Software.
+
+  PERMISSION & CONDITIONS
+  Permission is hereby granted, free of charge, to any person obtaining
+  a copy of the Font Software, to use, study, copy, merge, embed, modify,
+  redistribute, and sell modified and unmodified copies of the Font
+  Software, subject to the following conditions:
+
+  1) Neither the Font Software nor any of its individual components,
+  in Original or Modified Versions, may be sold by itself.
+
+  2) Original or Modified Versions of the Font Software may be bundled,
+  redistributed and/or sold with any software, provided that each copy
+  contains the above copyright notice and this license. These can be
+  included either as stand-alone text files, human-readable headers or
+  in the appropriate machine-readable metadata fields within text or
+  binary files as long as those fields can be easily viewed by the user.
+
+  3) No Modified Version of the Font Software may use the Reserved Font
+  Name(s) unless explicit written permission is granted by the corresponding
+  Copyright Holder. This restriction only applies to the primary font name as
+  presented to the users.
+
+  4) The name(s) of the Copyright Holder(s) or the Author(s) of the Font
+  Software shall not be used to promote, endorse or advertise any
+  Modified Version, except to acknowledge the contribution(s) of the
+  Copyright Holder(s) and the Author(s) or with their explicit written
+  permission.
+
+  5) The Font Software, modified or unmodified, in part or in whole,
+  must be distributed entirely under this license, and must not be
+  distributed under any other license. The requirement for fonts to
+  remain under this license does not apply to any document created
+  using the Font Software.
+
+  TERMINATION
+  This license becomes null and void if any of the above conditions are
+  not met.
+
+  DISCLAIMER
+  THE FONT SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTIES OF
+  MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT
+  OF COPYRIGHT, PATENT, TRADEMARK, OR OTHER RIGHT. IN NO EVENT SHALL THE
+  COPYRIGHT HOLDER BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+  INCLUDING ANY GENERAL, SPECIAL, INDIRECT, INCIDENTAL, OR CONSEQUENTIAL
+  DAMAGES, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+  FROM, OUT OF THE USE OR INABILITY TO USE THE FONT SOFTWARE OR FROM
+  OTHER DEALINGS IN THE FONT SOFTWARE.
+command: create-formula https://github.com/floriankarsten/space-grotesk/releases/download/2.0.0/SpaceGrotesk-2.0.0.zip

--- a/Formulas/timemachine_wa.yml
+++ b/Formulas/timemachine_wa.yml
@@ -21,7 +21,7 @@ extract: {}
 copyright: WadaLab, RareEarth
 command: create-formula https://modi.jpn.org/download/MODI_timemachine-wa_2017_0930.zip
 license_url: https://sourceforge.net/p/jis2004/wiki/index/
-requires_license_agreement: |-
+open_license: |-
   ※Wada Ken Hosomaru Gothic License
 
   * It can be used free of charge.


### PR DESCRIPTION
Fixes #180

Add adobe open source fonts. These fonts are openly-licensed fonts from the Adobe Fonts "Open Source" foundry listing:
* https://fonts.adobe.com/foundries/open-source

These fonts come from a variety of sources. To the best of my ability I have described them as Formulas properly, supplementing information in addition to the `create-formula` command.

Follow up: A number of fonts we are unable to directly import due to issues described at https://github.com/fontist/formulas/issues/180#issuecomment-2132482114.