### PR TITLE
fix: allow font_collections as alternative to fonts in schema validator

### DIFF
--- a/.github/scripts/validate_schema.rb
+++ b/.github/scripts/validate_schema.rb
@@ -9,7 +9,7 @@ require "optparse"
 require "date"
 
 class ValidateSchema
-  SCHEMA_V5_REQUIRED_FIELDS = %w[fonts resources].freeze
+  SCHEMA_V5_REQUIRED_FIELDS = %w[resources].freeze
   FONT_REQUIRED_FIELDS = %w[name styles].freeze
   STYLE_REQUIRED_FIELDS = %w[family_name type font].freeze
 
@@ -74,6 +74,8 @@ class ValidateSchema
     else
       validate_v4_schema(file, content)
     end
+
+    validate_fonts_or_collections(file, content)
 
     # Common validations
     validate_fonts(file, content)
@@ -141,10 +143,18 @@ class ValidateSchema
   end
 
   def validate_v4_schema(file, content)
-    %w[name fonts resources].each do |field|
+    %w[name resources].each do |field|
       unless content[field]
         add_error(file, "Missing required field: #{field}")
       end
+    end
+
+    validate_fonts_or_collections(file, content)
+  end
+
+  def validate_fonts_or_collections(file, content)
+    unless content["fonts"] || content["font_collections"]
+      add_error(file, "Missing required field: fonts or font_collections")
     end
   end
 


### PR DESCRIPTION
## Problem

The `formula-health` CI workflow fails because `validate_schema.rb` requires a top-level `fonts` field for all formulas. However, 1,291 formulas (1,285 macOS + 6 top-level) use `font_collections` instead — they package TTC (TrueType Collection) files where fonts are declared inside the collection, not at the top level.

## Fix

Changed `validate_schema.rb` to accept **either** `fonts` **or** `font_collections` as valid:

- Removed `fonts` from `SCHEMA_V5_REQUIRED_FIELDS` (kept `resources`)
- Added `validate_fonts_or_collections` check that requires at least one of `fonts` / `font_collections`
- Applied the same fix to the v4 schema path

## Result

All 1,291 false failures are resolved. Only non-blocking warnings remain (missing optional `name`, filename mismatches).