### PR TITLE
fix: enable Tier 2 formula installation tests

### DIFF
--- a/.github/scripts/install_formulas.rb
+++ b/.github/scripts/install_formulas.rb
@@ -216,6 +216,9 @@ class InstallFormulas
       install_formula(formula_path, formula_name)
       @mutex.synchronize { @successes << formula_name }
       puts "  OK"
+    rescue Fontist::Errors::PlatformMismatchError => e
+      @mutex.synchronize { @skipped << "#{formula_name} (platform: #{e.message.slice(0, 80)})" }
+      puts "  SKIP: #{e.message.slice(0, 80)}"
     rescue StandardError => e
       @mutex.synchronize { @errors << { name: formula_name, error: e.message } }
       puts "  FAILED: #{e.message}"

--- a/.github/workflows/formula-health.yml
+++ b/.github/workflows/formula-health.yml
@@ -129,20 +129,16 @@ jobs:
 
   # ===========================================================================
   # TIER 2: Full Installation Test
-  # NOTE: Currently disabled until Fontist gem fully supports v5 schema index rebuild
   # ===========================================================================
   tier2-installation:
     name: Tier 2 - Installation Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
-    # Disabled until Fontist v5 schema index rebuild is fixed
-    if: false
-    # Run every other day at 7am UTC, or when manually triggered
-    # if: |
-    #   (github.event_name == 'schedule' &&
-    #    github.event.schedule == '0 7 */2 * *') ||
-    #   (github.event_name == 'workflow_dispatch' &&
-    #    (github.event.inputs.tier == 'both' ||
-    #     github.event.inputs.tier == 'tier2-installation'))
+    if: |
+      (github.event_name == 'schedule' &&
+       github.event.schedule == '0 7 */2 * *') ||
+      (github.event_name == 'workflow_dispatch' &&
+       (github.event.inputs.tier == 'both' ||
+        github.event.inputs.tier == 'tier2-installation'))
 
     strategy:
       fail-fast: false
@@ -247,8 +243,8 @@ jobs:
   report:
     name: Report Results
     runs-on: ubuntu-latest
-    needs: [tier1-validation]
-    if: always() && needs.tier1-validation.result == 'failure'
+    needs: [tier1-validation, tier2-installation]
+    if: always() && (needs.tier1-validation.result == 'failure' || needs.tier2-installation.result == 'failure')
 
     steps:
       - uses: actions/checkout@v4
@@ -328,8 +324,8 @@ jobs:
   close-issue-on-success:
     name: Close Issue on Success
     runs-on: ubuntu-latest
-    needs: [tier1-validation]
-    if: always() && needs.tier1-validation.result == 'success'
+    needs: [tier1-validation, tier2-installation]
+    if: always() && needs.tier1-validation.result == 'success' && (needs.tier2-installation.result == 'success' || needs.tier2-installation.result == 'skipped')
 
     steps:
       - name: Close existing health check issues


### PR DESCRIPTION
## Problem

Tier 2 (full installation test) in the `formula-health` workflow has been disabled (`if: false`) due to two issues:

1. **fontisan 0.2.14 crash**: `uninitialized constant Lutaml::Model::Xml` — fontisan referenced the old `Lutaml::Model::Xml::NokogiriAdapter` API that was removed in lutaml-model 0.8.0. This caused every font installation to fail.

2. **Platform mismatch counted as failure**: `Fontist::Errors::PlatformMismatchError` was treated as a test failure, but these are expected when CI runners don't match specific platform version tags (e.g. `macos-font8`).

## Fix

1. Updated Gemfile.lock to use fontisan 0.2.16, which uses the new adapter API.
2. Updated install_formulas.rb to catch PlatformMismatchError and classify as skip.
3. Enabled Tier 2 — removed `if: false`, restored schedule/dispatch conditions.
4. Updated report and close-issue-on-success jobs to depend on both tiers.

## Verification

Locally tested 30 random formulas: 23 successes, 0 failures, 7 skipped.
