### PR TITLE
feat: add full formula scan (weekly + on-demand)

### DIFF
--- a/.github/scripts/install_formulas.rb
+++ b/.github/scripts/install_formulas.rb
@@ -44,6 +44,10 @@ class InstallFormulas
         @sample_size = n
       end
 
+      opts.on("--full", "Test all formulas (no rotation)") do
+        @full = true
+      end
+
       opts.on("--continue-on-error", "Don't stop on errors") do
         @continue_on_error = true
       end
@@ -56,11 +60,13 @@ class InstallFormulas
     @directory ||= "Formulas"
     @platform ||= nil
     @every_platform ||= false
+    @rotation_day = nil if @full
     @rotation_day ||= calculate_rotation_day
     @group ||= nil
     @sample_size ||= nil
     @continue_on_error ||= false
     @output_file ||= nil
+    @full ||= false
 
     @errors = []
     @successes = []
@@ -74,7 +80,7 @@ class InstallFormulas
     puts "=" * 60
     puts "Directory:     #{@directory}"
     puts "Platform:      #{@platform || 'all'}"
-    puts "Rotation day:  #{@rotation_day}"
+    puts "Mode:          #{@full ? 'full scan' : "rotation day #{@rotation_day}"}"
     puts "Group filter:  #{@group || 'none'}"
     puts "=" * 60
     puts

--- a/.github/workflows/formula-health.yml
+++ b/.github/workflows/formula-health.yml
@@ -13,8 +13,10 @@ on:
   schedule:
     # Tier 1: Fast validation - Daily at 6am UTC
     - cron: '0 6 * * *'
-    # Tier 2: Full installation - Every other day at 7am UTC
+    # Tier 2: Rotation installation - Every other day at 7am UTC
     - cron: '0 7 */2 * *'
+    # Tier 2: Full scan - Weekly on Monday at 8am UTC
+    - cron: '0 8 * * 1'
   workflow_dispatch:
     inputs:
       tier:
@@ -26,6 +28,7 @@ on:
           - both
           - tier1-validation
           - tier2-installation
+          - tier2-full-scan
       group:
         description: 'Formula group to test (for tier 2)'
         required: false
@@ -238,13 +241,141 @@ jobs:
           fi
 
   # ===========================================================================
+  # TIER 2 FULL SCAN: Test ALL formulas (weekly or on-demand)
+  # Traffic: ~1.1GB on Ubuntu, ~3GB on macOS. ~40-60 min per platform.
+  # ===========================================================================
+  tier2-full-scan:
+    name: Full Scan (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    if: |
+      (github.event_name == 'schedule' &&
+       github.event.schedule == '0 8 * * 1') ||
+      (github.event_name == 'workflow_dispatch' &&
+       github.event.inputs.tier == 'tier2-full-scan')
+
+    strategy:
+      fail-fast: false
+      max-parallel: 1
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Determine platform
+        id: config
+        shell: bash
+        run: |
+          case "${{ matrix.os }}" in
+            ubuntu-latest) PLATFORM="linux" ;;
+            macos-latest)  PLATFORM="macos" ;;
+            windows-latest) PLATFORM="windows" ;;
+          esac
+          echo "platform=${PLATFORM}" >> $GITHUB_OUTPUT
+          echo "Platform: ${PLATFORM}"
+
+      - name: Run full scan
+        id: install
+        shell: bash
+        continue-on-error: true
+        timeout-minutes: 120
+        run: |
+          echo "::group::Full Formula Scan (${{ steps.config.outputs.platform }})"
+
+          CMD="bundle exec ruby .github/scripts/install_formulas.rb"
+          CMD="${CMD} --directory Formulas"
+          CMD="${CMD} --full"
+          CMD="${CMD} --platform ${{ steps.config.outputs.platform }}"
+          CMD="${CMD} --continue-on-error"
+          CMD="${CMD} --output full-scan-${{ steps.config.outputs.platform }}.yml"
+
+          echo "Running: ${CMD}"
+          ${CMD} 2>&1 | tee scan-output.txt
+
+          echo "::endgroup::"
+
+      - name: Generate failure report
+        id: report
+        if: always()
+        shell: bash
+        run: |
+          if [ ! -f "full-scan-${{ steps.config.outputs.platform }}.yml" ]; then
+            echo "has_failures=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          # Extract failure count from results
+          FAILURES=$(ruby -ryaml -e "
+            data = YAML.load_file('full-scan-${{ steps.config.outputs.platform }}.yml')
+            failures = data['failures'] || []
+            puts failures.size
+          " 2>/dev/null || echo "unknown")
+
+          echo "failure_count=${FAILURES}" >> $GITHUB_OUTPUT
+
+          if [ "${FAILURES}" != "0" ] && [ "${FAILURES}" != "unknown" ]; then
+            echo "has_failures=true" >> $GITHUB_OUTPUT
+
+            # Build failure list for summary
+            ruby -ryaml -e "
+              data = YAML.load_file('full-scan-${{ steps.config.outputs.platform }}.yml')
+              failures = data['failures'] || []
+              successes = data['successes'] || []
+              skipped = data['skipped'] || []
+              puts \"Successes: #{successes.size}\"
+              puts \"Failures:  #{failures.size}\"
+              puts \"Skipped:   #{skipped.size}\"
+              puts
+              if failures.any?
+                puts 'FAILED FORMULAS:'
+                failures.each do |f|
+                  puts \"  - #{f['name']}: #{f['error'].to_s.split('\n').first[0..120]}\"
+                end
+              end
+            " 2>/dev/null | tee failure-report.txt
+          else
+            echo "has_failures=false" >> $GITHUB_OUTPUT
+            echo "No failures found." > failure-report.txt
+          fi
+
+      - name: Upload full scan results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: full-scan-${{ steps.config.outputs.platform }}
+          path: |
+            scan-output.txt
+            full-scan-${{ steps.config.outputs.platform }}.yml
+            failure-report.txt
+          retention-days: 90
+
+      - name: Summary
+        if: always()
+        shell: bash
+        run: |
+          echo "## Full Scan Results (${{ steps.config.outputs.platform }})" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [ -f "failure-report.txt" ]; then
+            echo '```' >> $GITHUB_STEP_SUMMARY
+            cat failure-report.txt >> $GITHUB_STEP_SUMMARY
+            echo '```' >> $GITHUB_STEP_SUMMARY
+          else
+            echo "Scan did not complete." >> $GITHUB_STEP_SUMMARY
+          fi
+
+  # ===========================================================================
   # Report: Aggregate results and create issue on failure
   # ===========================================================================
   report:
     name: Report Results
     runs-on: ubuntu-latest
-    needs: [tier1-validation, tier2-installation]
-    if: always() && (needs.tier1-validation.result == 'failure' || needs.tier2-installation.result == 'failure')
+    needs: [tier1-validation, tier2-installation, tier2-full-scan]
+    if: always() && (needs.tier1-validation.result == 'failure' || needs.tier2-installation.result == 'failure' || needs.tier2-full-scan.result == 'failure')
 
     steps:
       - uses: actions/checkout@v4
@@ -277,8 +408,8 @@ jobs:
 
       - name: Create or update issue
         run: |
-          # Build issue body
-          cat > issue-body.md << 'EOF'
+          # Build issue body with failure details
+          cat > issue-body.md << EOF
           ## Formula Health Check Failed
 
           The periodic formula health check detected failures.
@@ -288,13 +419,32 @@ jobs:
           ### Tier 1 Validation
           Status: ${{ needs.tier1-validation.result }}
 
-          ### Artifacts
-          - [Download results](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)
+          ### Tier 2 Installation
+          Status: ${{ needs.tier2-installation.result }}
 
-          ---
-          *This issue was automatically created by the formula-health workflow.*
-          *It will be auto-closed when all health checks pass.*
+          ### Tier 2 Full Scan
+          Status: ${{ needs.tier2-full-scan.result }}
           EOF
+
+          # Append full scan failure details if available
+          for platform in linux macos windows; do
+            report_file="results/full-scan-${platform}/failure-report.txt"
+            if [ -f "$report_file" ] && grep -q "FAILED FORMULAS" "$report_file"; then
+              echo "" >> issue-body.md
+              echo "### Full Scan Failures (${platform})" >> issue-body.md
+              echo '```' >> issue-body.md
+              cat "$report_file" >> issue-body.md
+              echo '```' >> issue-body.md
+            fi
+          done
+
+          echo "" >> issue-body.md
+          echo "### Artifacts" >> issue-body.md
+          echo "- [Download results](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)" >> issue-body.md
+          echo "" >> issue-body.md
+          echo "---" >> issue-body.md
+          echo "*This issue was automatically created by the formula-health workflow.*" >> issue-body.md
+          echo "*It will be auto-closed when all health checks pass.*" >> issue-body.md
 
           if [ "${{ steps.check.outputs.is_existing }}" == "true" ]; then
             # Update existing issue with comment
@@ -324,8 +474,8 @@ jobs:
   close-issue-on-success:
     name: Close Issue on Success
     runs-on: ubuntu-latest
-    needs: [tier1-validation, tier2-installation]
-    if: always() && needs.tier1-validation.result == 'success' && (needs.tier2-installation.result == 'success' || needs.tier2-installation.result == 'skipped')
+    needs: [tier1-validation, tier2-installation, tier2-full-scan]
+    if: always() && needs.tier1-validation.result == 'success' && (needs.tier2-installation.result == 'success' || needs.tier2-installation.result == 'skipped') && (needs.tier2-full-scan.result == 'success' || needs.tier2-full-scan.result == 'skipped')
 
     steps:
       - name: Close existing health check issues


### PR DESCRIPTION
## Problem

Tier 2 only tests rotation subsets (~half of formulas per day, non-Google only on Day 2). We have no visibility into which of the ~4,280 formulas actually fail to install.

## Solution

Adds a **Tier 2 Full Scan** that tests ALL formulas on all 3 platforms without rotation.

### Traffic estimate per full scan

| Platform | Formulas | Download | Time |
|----------|----------|----------|------|
| Ubuntu | ~2,200 | ~1.1GB | ~40 min |
| macOS | ~2,800 | ~3GB | ~60 min |
| Windows | ~2,200 | ~1.1GB | ~40 min |

Platforms run **sequentially** (max-parallel: 1) to limit CDN impact. Total: ~5GB traffic, ~2.5 hours wall time.

### Changes

- `install_formulas.rb`: `--full` flag skips rotation, tests everything
- `formula-health.yml`: new `tier2-full-scan` job with 120min timeout
- **Scheduled**: Weekly on Monday 8am UTC
- **On-demand**: Via `workflow_dispatch` with `tier2-full-scan` option
- Results retained 90 days with per-platform failure reports
- Report job includes full-scan failure details in auto-created GitHub issues

### Testing the full scan

After merge, trigger manually:
```
gh workflow run formula-health.yml --ref v5 -f tier=tier2-full-scan
```
