### PR TITLE
fix(docs): merge batch assets in combine job to fix client-side routing 404

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -249,7 +249,13 @@ jobs:
           pattern: dist-batch-*
           path: batches
 
-      - name: Merge batch browse pages
+      - name: Merge batch browse pages and assets
+        # Each batch's VitePress build produces its own content-hashed JS chunks
+        # (app.HASH.js, browse_index.md.HASH.lean.js, etc.) because the page set
+        # differs per batch. Browse HTML from batch N references batch-N's hashes,
+        # so we must merge ALL batches' assets/ into dist/assets/ — otherwise
+        # client-side navigation 404s on the missing chunks (the SSR HTML still
+        # works on full page refresh, which masked this for a long time).
         run: |
           for d in batches/dist-batch-*/; do
             [ -d "$d" ] || continue
@@ -257,6 +263,10 @@ jobs:
             if [ -d "$d/browse" ]; then
               mkdir -p dist/browse
               cp -r "$d/browse/"* dist/browse/ 2>/dev/null || true
+            fi
+            if [ -d "$d/assets" ]; then
+              mkdir -p dist/assets
+              cp -r "$d/assets/"* dist/assets/ 2>/dev/null || true
             fi
           done
         shell: bash


### PR DESCRIPTION
## Problem

Clicking a formula on `/browse/` changed the URL but showed 404. Refreshing the page loaded it correctly. Classic client-side routing failure.

## Root cause

VitePress produces **different content-hashed JS chunks per build** when the page set differs. Each `build-batch` job runs its own `vitepress build`, so 9 batches produce 9 distinct `app.HASH.js` files. The `combine` job was deploying `dist-main`'s `assets/` directory only — but browse HTML from each batch references batch-specific hashes that weren't in the deployed assets.

Verified by downloading artifacts from the latest deploy (run 27699130632):

| Artifact | `app.HASH.js` hash |
|---|---|
| dist-main | `CUFvjMGd` |
| dist-batch-0 | `tggRrD32` |
| dist-batch-1 | `lhlnUi-u` |
| dist-batch-2 | `wADyZrW9` |
| dist-batch-3 | `NxYOTzkh` |
| dist-batch-4 | `TU-EUwTC` |
| dist-batch-5 | `j-JEY3xz` |
| dist-batch-6 | `Bh3mvEjZ` |
| dist-batch-7 | `Sac3zhiF` |
| dist-batch-8 | `BldWXoD6` |

**None matched.** Browse HTML from batch-N references batch-N's hash, which wasn't deployed → client-side navigation 404s on the missing chunk. The SSR HTML was correct (which is why refresh worked, masking the bug).

## Fix

In [`docs.yml`](blob/fix/docs-batch-assets-merge/.github/workflows/docs.yml)'s `combine` job, also `cp -r` each batch's `assets/` into `dist/assets/`. Content-hashing guarantees no filename conflicts (same content → same filename, different content → different filename). Total added payload is ~9 small duplicate-ish `app.HASH.js` chunks (~few KB each), acceptable for a static site.

## Verification

After merge and deploy:
1. Go to `https://www.fontist.org/formulas/browse/`
2. Click any formula — should load directly (no 404, no refresh needed)
3. Confirm in browser DevTools that `/formulas/assets/app.<HASH>.js` returns 200 (was 404)

## Why this was masked

- The PR #263 SSR HTML is correct, so manual URL navigation or refresh works
- Client-side routing failure only manifests on in-page click navigation
- The previous "click → 404" reports were attributed to the clean URLs issue, which PR #263 fixed
- This is a separate, deeper issue that PR #263's verification missed (because Playwright test navigated directly via URL, not by clicking links)
