### PR TITLE
fix(docs): bypass SPA routing for formula links to fix click→404

### DIFF
--- a/docs/.vitepress/theme/FormulaBrowser.vue
+++ b/docs/.vitepress/theme/FormulaBrowser.vue
@@ -204,6 +204,17 @@ function scrollToLetter(letter) {
   if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' })
 }
 
+function goToFormula(slug) {
+  // Formula pages are rendered in CI batches (docs.yml build-batch matrix),
+  // and each batch's VitePress router manifest only includes its own pages.
+  // SPA navigation from /browse/ to a formula in a different batch hits a
+  // "Page not found" 404 even though the SSR HTML exists on the server.
+  // Bypass SPA routing for formula clicks — full page load fetches the
+  // correct HTML which loads the correct app chunk for that formula's batch.
+  const basePath = import.meta.env.BASE_URL || '/'
+  window.location.href = `${basePath}browse/${slug}/`
+}
+
 function toggleLicense(value) {
   if (value === 'all') {
     selectedLicenses.value = ['all']
@@ -255,7 +266,7 @@ function toggleSource(value) {
           <div v-for="letter in activeLetters" :key="letter" :id="'letter-' + letter" class="letter-group">
             <h3 class="letter-heading">{{ letter }}</h3>
             <div class="formula-items">
-              <a v-for="f in groupedFormulas[letter]" :key="f.slug" :href="f.slug + '/'" class="formula-item">
+              <a v-for="f in groupedFormulas[letter]" :key="f.slug" :href="f.slug + '/'" class="formula-item" @click.stop.prevent="goToFormula(f.slug)">
                 <div class="formula-main">
                   <span class="formula-name">{{ f.name }}</span>
                   <span class="formula-key">{{ f.formulaName }}</span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -82,6 +82,14 @@ function getLicenseBadge(f) {
   return `<img src="${basePath}licenses/unknown.svg" alt="Unknown" class="license-icon" title="Unknown">`
 }
 
+function goToFormula(slug) {
+  // Formula pages are rendered in CI batches, and each batch's VitePress
+  // router manifest only knows about its own pages. SPA navigation from
+  // the homepage to a formula in a different batch 404s. Force a full page
+  // load so the server sends the correct HTML with the correct app chunk.
+  window.location.href = `${basePath}browse/${slug}/`
+}
+
 function getSourceBadge(f) {
   if (!f) return `<img src="${basePath}sources/fontist.svg" alt="Expert Curated" class="source-icon" title="Expert Curated">`
   if (f.sourceType === 'google') return `<img src="${basePath}sources/google.svg" alt="Google Fonts" class="source-icon" title="Google Fonts">`
@@ -159,6 +167,7 @@ watch(searchQuery, (val) => {
         :href="basePath + 'browse/' + item.slug + '/'"
         :class="getItemClass(idx)"
         @mouseover="selectedIndex = idx"
+        @click.stop.prevent="goToFormula(item.slug)"
       >
         <div class="autocomplete-main">
           <span class="autocomplete-name">{{ item.name }}</span>


### PR DESCRIPTION
## Problem

On `/browse/`, clicking a formula changed the URL but the page showed 404. Refreshing loaded the page correctly. Same issue from any page with cross-batch formula links.

## Root cause

VitePress generates **per-batch router manifests**. Each `build-batch` job in `docs.yml` runs its own `vitepress build`, and the resulting app chunk (`app.HASH.js`) contains a route lookup table that ONLY includes that batch's pages.

When you load `/browse/` from batch-N's app chunk and click a formula that lives in batch-M (M ≠ N):
1. Vue Router looks up the route in batch-N's manifest
2. Doesn't find it (manifest only knows batch-N's pages)
3. Throws `Page not found` and renders NotFound
4. **Never even tries to fetch** the formula's chunk

This is why PR #264 (which deploys all batch assets) didn't fix the click 404 — the asset exists, but the router doesn't know the route exists.

Verified by downloading the deployed `app.BZgrPav2.js` (from `/browse/`) and inspecting: it has 0 references to `browse_andale.md` or any other batch-N's pages. The router manifest is per-batch by design.

This is a fundamental limitation of multi-batch VitePress builds. The "proper" fix would be a single-pass build with all 4,283 pages, but that OOMs even with 6 GB heap + 8 GB swap (which is why the project went to multi-batch in the first place).

## Fix

Bypass SPA routing for formula navigation. Add `@click.stop.prevent="goToFormula(slug)"` to formula links in:
- [`docs/.vitepress/theme/FormulaBrowser.vue`](blob/fix/browse-spa-routing-bypass/docs/.vitepress/theme/FormulaBrowser.vue) — the browse grid
- [`docs/index.md`](blob/fix/browse-spa-routing-bypass/docs/index.md) — the homepage autocomplete dropdown

`goToFormula(slug)` calls `window.location.href = ...`, triggering a **full page load**. The server sends the correct HTML which references the correct app chunk for that formula's batch. The user sees the same behavior as their manual "refresh" workaround, just automatic.

### Preserved behavior

- ✅ `<a href>` is still set — right-click "Open in new tab", Ctrl+click, and screen readers all work normally
- ✅ Keyboard Enter navigation (already used `window.location.href` directly, no change needed)
- ✅ SPA routing still works for all other internal links (guide, licenses, search)
- ✅ Only cross-batch formula navigation is affected — slight UX regression (no instant SPA transition), but **always works**

## Verification

After merge and deploy:
1. Go to `https://www.fontist.org/formulas/browse/`
2. Click any formula — page should load immediately (no 404, no manual refresh needed)
3. Same for clicking autocomplete results on `https://www.fontist.org/formulas/`
