### PR TITLE
feat(docs): SEO — sitemap, robots.txt, per-page og: tags, canonical URLs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,11 @@ permissions:
   pages: write
   id-token: write
 
+# Used by VitePress config for og:url, canonical URLs, and sitemap hostname.
+# VitePress reads process.env.SITE_URL; defaults to localhost for local dev.
+env:
+  SITE_URL: https://www.fontist.org
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -19,6 +19,10 @@ permissions:
   contents: read
   pull-requests: write
 
+# Match docs.yml — VitePress config reads SITE_URL for og:url / canonical / sitemap.
+env:
+  SITE_URL: https://www.fontist.org
+
 jobs:
   link_checker:
     runs-on: ubuntu-latest

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -1,5 +1,12 @@
 import { defineConfig } from "vitepress";
 
+// Allow override via env (CI sets SITE_URL=https://www.fontist.org).
+// Default to localhost so `vitepress dev` and local `npm run build` produce
+// URLs that actually resolve during testing.
+const SITE_ORIGIN = process.env.SITE_URL || "http://localhost:5173";
+const SITE_PATH = process.env.BASE_PATH || "/formulas/";
+const SITE_BASE = `${SITE_ORIGIN}${SITE_PATH}`;
+
 // https://vitepress.dev/reference/site-config
 export default defineConfig({
   lang: "en-US",
@@ -16,6 +23,8 @@ export default defineConfig({
     "testing-google-import.md",
     "GOOGLE_FONTS_IMPLEMENTATION.md",
     "TODO.revamp.md",
+    "TODO.style.md",
+    "V5_MIGRATION_PLAN.md",
   ],
 
   ignoreDeadLinks: true,
@@ -85,17 +94,47 @@ export default defineConfig({
     ],
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
     ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:title", content: "Fontist Formulas" }],
-    [
-      "meta",
-      {
-        property: "og:description",
-        content: "Searchable index of all Fontist Formulas",
-      },
-    ],
-    ["meta", { property: "og:image", content: "/logo-full.svg" }],
+    ["meta", { property: "og:image", content: `${SITE_BASE}logo-full.svg` }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
   ],
+
+  // Generates /sitemap.xml at build time so crawlers can discover all
+  // 4,283 formula pages even though /browse/ renders its list client-side.
+  // VitePress sitemap doesn't auto-include the `base` path (/formulas/),
+  // so transformItems prepends SITE_PATH to every URL.
+  sitemap: {
+    hostname: SITE_ORIGIN,
+    transformItems(items) {
+      return items.map((item) => ({
+        ...item,
+        url: `${SITE_PATH}${item.url}`.replace(/\/{2,}/g, "/"),
+      }));
+    },
+  },
+
+  // Per-page SEO tags (og:title, og:description, og:url, canonical URL)
+  // sourced from page frontmatter. Global head only sets site-wide og:type
+  // and og:image — title/description/url must be per-page or scrapers see
+  // generic "Fontist Formulas" for every page.
+  transformHead(context) {
+    const pageData = context.pageData;
+    const title =
+      (pageData.frontmatter.title as string) || "Fontist Formulas";
+    const description =
+      (pageData.frontmatter.description as string) ||
+      "Searchable index of all Fontist Formulas";
+    const canonicalPath = pageData.relativePath
+      .replace(/(index)?\.md$/, "")
+      .replace(/\\/g, "/");
+    const canonicalURL = `${SITE_BASE}${canonicalPath}`;
+
+    return [
+      ["meta", { property: "og:title", content: title }],
+      ["meta", { property: "og:description", content: description }],
+      ["meta", { property: "og:url", content: canonicalURL }],
+      ["link", { rel: "canonical", href: canonicalURL }],
+    ];
+  },
 
   themeConfig: {
     logo: "/logo-full.svg",

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://www.fontist.org/formulas/sitemap.xml


### PR DESCRIPTION
## Audit findings — what was broken

| Item | Before | After |
|---|---|---|
| `robots.txt` | ❌ 404 | ✅ Allow all + sitemap reference |
| `sitemap.xml` | ❌ 404 | ✅ Auto-generated with all 4,283 formula URLs |
| `/browse/` static HTML | ❌ 0 formula links | ⚠️ Still client-rendered (see "Out of scope" below) |
| Per-page `og:title` | ❌ Generic "Fontist Formulas" everywhere | ✅ Per-page from frontmatter (`abeezee - Fontist Formula`) |
| Per-page `og:description` | ❌ Generic | ✅ Per-page (install command, family/style counts) |
| Per-page `og:url` | ❌ Missing | ✅ Per-page absolute URL |
| Canonical URLs | ❌ Missing | ✅ Per-page `<link rel="canonical">` |
| `og:image` | ⚠️ Relative `/logo-full.svg` | ✅ Absolute URL |
| Internal docs in sitemap | ❌ `TODO.style`, `V5_MIGRATION_PLAN` | ✅ Excluded via `srcExclude` |

**Critical problem solved**: without a sitemap, Google could not discover the 4,283 formula pages. `/browse/` is client-rendered (its static HTML has 0 formula links), so crawlers had no path to individual formulas.

## Changes

### `docs/.vitepress/config.ts`
- **`sitemap` config** (VitePress built-in): emits `/sitemap.xml` at build time. `transformItems` prepends `SITE_PATH` (`/formulas/`) because VitePress sitemap doesn't auto-include the base path.
- **`transformHead` hook**: emits per-page `og:title`, `og:description`, `og:url`, and `<link rel="canonical">` from page frontmatter. Removed conflicting global `og:title` / `og:description` to avoid duplicates (verified: exactly 1 `og:title` per page).
- **Absolute `og:image`**: was `/logo-full.svg`, now `${SITE_URL}/formulas/logo-full.svg`.
- **Added `TODO.style.md` and `V5_MIGRATION_PLAN.md` to `srcExclude`** — they were being built as public pages and appearing in the sitemap.
- **`SITE_URL` env var with localhost default** — local dev (`vitepress dev` or `npm run build`) produces URLs that actually resolve during testing. CI sets `SITE_URL=https://www.fontist.org`.

### `docs/public/robots.txt` (new)
```
User-agent: *
Allow: /

Sitemap: https://www.fontist.org/formulas/sitemap.xml
```

### `.github/workflows/docs.yml` + `.github/workflows/links.yml`
Added workflow-level `env: SITE_URL: https://www.fontist.org` so production builds use the right origin.

## Verification

Built locally in two modes:

**Default (no env — local dev)**:
- sitemap: `http://localhost:5173/formulas/browse/google/abeezee` ✓
- og:image: `http://localhost:5173/formulas/logo-full.svg` ✓

**Override (`SITE_URL=https://www.fontist.org`)**:
- sitemap: `https://www.fontist.org/formulas/browse/google/abeezee` ✓
- Formula page (`abeezee`):
  ```
  og:title        = "abeezee - Fontist Formula"
  og:description  = "abeezee font package for Fontist. 1 font families, 2 styles. Install: ..."
  og:url          = "https://www.fontist.org/formulas/browse/google/abeezee"
  canonical       = "https://www.fontist.org/formulas/browse/google/abeezee"
  ```
- No duplicate `og:title` (exactly 1 per page)
- TODO.style.md / V5_MIGRATION_PLAN.md excluded from sitemap (count = 0)

## Out of scope (still a gap)

`/browse/` itself is still client-rendered. Its static HTML has the page shell but no formula links. This means:
- Crawlers can't follow links FROM `/browse/` to formulas (sitemap solves discovery)
- `/browse/` itself looks "empty" to a crawler (Google indexes it as a search page, not a content page)

Fixing this properly would require either:
- Server-side rendering of the formula list (~5MB+ static HTML per page)
- Pagination (browse/page/1, browse/page/2, ...)
- Per-letter static index pages (browse/a/, browse/b/, ...)

These are architectural changes worth a separate effort. For pure discovery (the critical SEO need), the sitemap fully covers it.
