### PR TITLE
fix(docs): regenerate sitemap post-merge so it lists all 4,283 formula pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -287,8 +287,15 @@ jobs:
             mkdir -p "$dir"
             mv "$f" "$dir/index.html"
           done
-          echo "Rewrote $(find dist -type d -name index.html -exec dirname {} \; | wc -l) pages"
         shell: bash
+
+      - name: Regenerate sitemap
+        # VitePress sitemap is generated per-batch and only lists that batch's
+        # pages. The combined dist has 4,283 browse pages from the matrix build
+        # that the deployed sitemap would otherwise miss. Scan the final dist/
+        # and emit a complete sitemap.xml.
+        working-directory: docs
+        run: node generate-sitemap.js ../dist
 
       - name: Upload combined artifact
         uses: actions/upload-pages-artifact@v4

--- a/docs/build.js
+++ b/docs/build.js
@@ -186,6 +186,10 @@ async function main() {
   const rewritten = await rewriteCleanUrls(DIST_DIR);
   console.log(`Rewrote ${rewritten} pages`);
 
+  console.log("=== Regenerating sitemap ===");
+  const sitemapResult = spawnSync("node", ["generate-sitemap.js", DIST_DIR], { stdio: "inherit" });
+  if (sitemapResult.status !== 0) process.exit(sitemapResult.status ?? 1);
+
   console.log(`\n=== Build complete: ${await countHtmlFiles(DIST_DIR)} total HTML pages ===`);
 }
 

--- a/docs/generate-sitemap.js
+++ b/docs/generate-sitemap.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+// Regenerate dist/sitemap.xml from the final dist/ structure.
+//
+// VitePress's built-in sitemap config only sees the pages from its own build
+// — in the multi-batch CI pipeline (docs.yml build-main + build-batch matrix)
+// each batch's sitemap lists only that batch's pages. The combine job deploys
+// dist-main's sitemap, which is missing all 4,283 formula browse pages that
+// were merged in from the batches.
+//
+// Run this AFTER all browse pages have been merged AND the clean-URLs post-
+// process has converted foo.html -> foo/index.html. The script scans dist/
+// for index.html files and emits one <url> entry per page.
+
+import { readdir, stat, writeFile } from "node:fs/promises";
+import { join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = fileURLToPath(new URL(".", import.meta.url));
+const DIST = process.argv[2] || join(__dirname, "..", ".vitepress", "dist");
+const ORIGIN = process.env.SITE_URL || "http://localhost:5173";
+const BASE_PATH = process.env.BASE_PATH || "/formulas/";
+
+// 404 etc. shouldn't appear in the sitemap.
+const EXCLUDE_PATHS = new Set(["404"]);
+
+async function findIndexFiles(dir) {
+  const out = [];
+  const entries = await readdir(dir, { withFileTypes: true });
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      out.push(...await findIndexFiles(full));
+    } else if (e.name === "index.html") {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function escapeXml(s) {
+  return s.replace(/[<>&'"]/g, (c) => ({
+    "<": "&lt;",
+    ">": "&gt;",
+    "&": "&amp;",
+    "'": "&apos;",
+    '"': "&quot;",
+  }[c]));
+}
+
+async function main() {
+  const files = await findIndexFiles(DIST);
+  const entries = [];
+  for (const f of files) {
+    const relPath = relative(DIST, f).split(sep).slice(0, -1).join("/");
+    if (EXCLUDE_PATHS.has(relPath)) continue;
+    const url = `${BASE_PATH}${relPath}/`.replace(/\/{2,}/g, "/");
+    let lastmod;
+    try {
+      lastmod = (await stat(f)).mtime.toISOString();
+    } catch {
+      lastmod = new Date().toISOString();
+    }
+    entries.push(
+      `  <url><loc>${escapeXml(`${ORIGIN}${url}`)}</loc><lastmod>${lastmod}</lastmod></url>`
+    );
+  }
+  // Stable sort by URL for reproducible builds.
+  entries.sort();
+  const xml =
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    `${entries.join("\n")}\n` +
+    `</urlset>\n`;
+  await writeFile(join(DIST, "sitemap.xml"), xml);
+  console.log(`Generated sitemap.xml with ${entries.length} URLs`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
## Problem

PR #266 enabled VitePress's built-in sitemap config, but on the live site the deployed sitemap only listed ~10 URLs (`/browse/`, `/guide/*`, `/licenses/*`). The **4,283 formula pages were missing** — defeating the entire point of the sitemap (crawlers still can't discover individual formula pages).

## Root cause

VitePress generates its sitemap per-batch during `vitepress build`. The CI pipeline runs `vitepress build` 10 times:
- `build-main` (1 build — main site only, no formula pages)
- `build-batch` (9 builds — 500 formula pages each)

Each build emits its own `sitemap.xml` listing only that build's pages.

The `combine` job in `docs.yml` downloads `dist-main` (which contains its sitemap) and merges `browse/` from each batch — but **the sitemap from `dist-main` is what gets deployed**. The merged browse pages don't update it.

So the deployed sitemap lists:
- ✅ `/browse/` (browse index — built in `dist-main`)
- ✅ `/guide/*`, `/licenses/*`, homepage
- ❌ All 4,283 `/browse/<slug>/` pages (built in batches)

## Fix

New script [`docs/generate-sitemap.js`](blob/fix/docs-sitemap-regenerate/docs/generate-sitemap.js):
- Walks the final `dist/` structure
- Finds every `index.html` (post-clean-URLs rewrite)
- Emits one `<url>` per page with lastmod timestamp
- Excludes `404` page
- Stable-sorted by URL for reproducible builds
- Reads `SITE_URL` env var (defaults to localhost for local dev)

Wired in two places:

**1. [`docs/build.js`](blob/fix/docs-sitemap-regenerate/docs/build.js)** — runs after `rewriteCleanUrls()`. Used by local `npm run build` and the `link_checker` workflow.

**2. [`.github/workflows/docs.yml`](blob/fix/docs-sitemap-regenerate/.github/workflows/docs.yml) `combine` job** — new step `Regenerate sitemap` after `Merge batch browse pages and assets` and after `Rewrite clean URLs to directory style`, before `Upload combined artifact`.

## Verification (local)

Built with 3 browse pages (abeezee, roboto, open_sans) and ran the full pipeline (generate → vitepress build → post-process → regenerate sitemap):

```
Generated sitemap.xml with 42 URLs
```

Sample URLs include the 3 browse pages + main site pages (404 excluded). In production with 4,283 formulas, the sitemap will list ~4,300 URLs.

## Why the post-process approach

VitePress's built-in sitemap can't be made to know about pages from other batches — it generates the sitemap during build, and each batch only sees its own pages. A post-build regenerator is the cleanest fix: scan the final `dist/` and emit a complete sitemap.
