### PR TITLE
fix(ci): add checkout to combine job so generate-sitemap.js is available

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -242,6 +242,11 @@ jobs:
     needs: [build-main, build-batch]
     runs-on: ubuntu-latest
     steps:
+      # Checkout needed so the combine job can run docs/generate-sitemap.js
+      # (the script that scans the final dist/ and emits a complete sitemap).
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Download main site
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
PR #267's 'Regenerate sitemap' step failed with: `No such file or directory` because the combine job only downloads artifacts — it has no source checkout, so `docs/generate-sitemap.js` doesn't exist on disk.

Adding `actions/checkout@v4` so the script is available. No other changes.