### PR TITLE
feat(docs): shared og:image + per-page og:title from H1

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -94,7 +94,7 @@ export default defineConfig({
     ],
     ["link", { rel: "manifest", href: "/site.webmanifest" }],
     ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:image", content: `${SITE_BASE}logo-full.svg` }],
+    ["meta", { property: "og:image", content: `${SITE_ORIGIN}/og-image.png` }],
     ["meta", { name: "twitter:card", content: "summary_large_image" }],
   ],
 
@@ -118,8 +118,7 @@ export default defineConfig({
   // generic "Fontist Formulas" for every page.
   transformHead(context) {
     const pageData = context.pageData;
-    const title =
-      (pageData.frontmatter.title as string) || "Fontist Formulas";
+    const title = pageData.title || "Fontist Formulas";
     const description =
       (pageData.frontmatter.description as string) ||
       "Searchable index of all Fontist Formulas";


### PR DESCRIPTION
Two small SEO consistency fixes for the formulas subsite, aligning it with fontist.org and the other subsites.

## Changes

### 1. `og:image` → shared PNG

`https://www.fontist.org/formulas/logo-full.svg` → `https://www.fontist.org/og-image.png`

The SVG was subsite-local and SVG has poor support on Twitter/Facebook/LinkedIn. The PNG is the shared social card already used across fontist.org, fontist, and fontisan.

### 2. Per-page `og:title` from H1 (not just frontmatter)

`transformHead` was using `pageData.frontmatter.title || "Fontist Formulas"`. Most formulas pages (guide, browse, formula pages) have **no** frontmatter title, so every page showed the site-wide `"Fontist Formulas"` as its `og:title`.

Changed the fallback to `pageData.title` — VitePress's resolved title (`frontmatter.title || first H1`). Now `og:title` reflects the actual page.

| Page | Before | After |
|---|---|---|
| `/guide/` | Fontist Formulas | **Fontist Formulas Guide** |
| `/browse/<formula>/` | Fontist Formulas | **Mitimasu - Fontist Formula** (etc.) |

## Verification (local build, prod env)

`BASE_PATH=/formulas/ SITE_URL=https://www.fontist.org npm run build` → 4323 pages built. Confirmed in `dist`:

- `dist/guide/index.html`: `og:title="Fontist Formulas Guide"`, `og:image="https://www.fontist.org/og-image.png"`, `og:url="https://www.fontist.org/formulas/guide/"`.
- `dist/index.html`: `og:image="https://www.fontist.org/og-image.png"`.
- A formula browse page: `og:title="Mitimasu - Fontist Formula"`.

## Scope

Two-line change to `docs/.vitepress/config.ts`. No routing, build, or content changes — formulas already had directory-style URLs, sitemap, and `transformHead`; this just corrects the `og:image` source and the `og:title` fallback.
