### PR TITLE
fix(ci): surface formula failures in PR comments and issues (#225)

### DIFF
--- a/.github/scripts/check_urls.rb
+++ b/.github/scripts/check_urls.rb
@@ -10,6 +10,8 @@ require "uri"
 require "optparse"
 require "date"
 require "concurrent"
+require "json"
+require "fileutils"
 
 class CheckUrls
   TIMEOUT_SECONDS = 10
@@ -40,6 +42,14 @@ class CheckUrls
       opts.on("--verbose", "Show all URLs checked") do
         @verbose = true
       end
+
+      opts.on("--json-output FILE", "Write structured results as JSON") do |file|
+        @json_output = file
+      end
+
+      opts.on("--only PATHS", "Comma-separated list of formula paths (skip glob)") do |paths|
+        @only = paths.split(",").map(&:strip)
+      end
     end.parse!
 
     @directory ||= "Formulas"
@@ -47,11 +57,13 @@ class CheckUrls
     @sample_size ||= nil
     @google_only ||= false
     @verbose ||= false
+    @json_output ||= nil
 
     @errors = []
     @warnings = []
     @checked_urls = {}
     @mutex = Mutex.new
+    @started_at = Time.now.utc
   end
 
   def call
@@ -79,13 +91,19 @@ class CheckUrls
     pool.wait_for_termination
 
     print_results
+    write_json_results(formulas.size) if @json_output
+
     exit 1 if @errors.any?
   end
 
   private
 
   def collect_formulas
-    files = Dir.glob(File.join(@directory, "**/*.yml"))
+    files = if @only
+              @only.select { |f| File.exist?(f) }
+            else
+              Dir.glob(File.join(@directory, "**/*.yml"))
+            end
 
     files.select do |file|
       next false if file.include?("BACKUP")
@@ -180,60 +198,63 @@ class CheckUrls
     retries = 0
     redirects = 0
 
-    begin
-      http = Net::HTTP.new(uri.host, uri.port)
-      http.use_ssl = (uri.scheme == "https")
-      http.open_timeout = @timeout
-      http.read_timeout = @timeout
+    loop do
+      response = nil
+      begin
+        http = Net::HTTP.new(uri.host, uri.port)
+        http.use_ssl = (uri.scheme == "https")
+        http.open_timeout = @timeout
+        http.read_timeout = @timeout
 
-      request = Net::HTTP::Head.new(uri.request_uri)
-      request["User-Agent"] = "fontist-formula-check/1.0"
+        request = Net::HTTP::Head.new(uri.request_uri)
+        request["User-Agent"] = "fontist-formula-check/1.0"
 
-      response = http.request(request)
+        response = http.request(request)
+      rescue Net::OpenTimeout, Net::ReadTimeout
+        retries += 1
+        if retries <= MAX_RETRIES
+          sleep(RETRY_DELAY)
+          next
+        end
+        @mutex.synchronize { @checked_urls[url] = :error }
+        return { status: :error, message: "Timeout after #{@timeout}s" }
+      rescue SocketError => e
+        @mutex.synchronize { @checked_urls[url] = :error }
+        return { status: :error, message: "DNS/Network error: #{e.message}" }
+      rescue StandardError => e
+        @mutex.synchronize { @checked_urls[url] = :error }
+        return { status: :error, message: "Error: #{e.message}" }
+      end
 
       case response.code.to_i
       when 200..299
         @mutex.synchronize { @checked_urls[url] = :ok }
-        { status: :ok, message: "OK (#{response.code})" }
+        return { status: :ok, message: "OK (#{response.code})" }
       when 301, 302, 303, 307, 308
         location = response["Location"]
         if location && redirects < 3
           redirects += 1
           uri = URI.parse(location)
-          retry
+          next
         end
         @mutex.synchronize { @checked_urls[url] = :warning }
-        { status: :warning, message: "Redirect (#{response.code}) -> #{location}" }
+        return { status: :warning, message: "Redirect (#{response.code}) -> #{location}" }
       when 403
         @mutex.synchronize { @checked_urls[url] = :warning }
-        { status: :warning, message: "Forbidden (403) - may need special headers" }
+        return { status: :warning, message: "Forbidden (403) - may need special headers" }
       when 404
         @mutex.synchronize { @checked_urls[url] = :error }
-        { status: :error, message: "Not Found (404)" }
+        return { status: :error, message: "Not Found (404)" }
       when 429
         @mutex.synchronize { @checked_urls[url] = :warning }
-        { status: :warning, message: "Rate Limited (429)" }
+        return { status: :warning, message: "Rate Limited (429)" }
       when 500..599
         @mutex.synchronize { @checked_urls[url] = :error }
-        { status: :error, message: "Server Error (#{response.code})" }
+        return { status: :error, message: "Server Error (#{response.code})" }
       else
         @mutex.synchronize { @checked_urls[url] = :warning }
-        { status: :warning, message: "Unexpected status: #{response.code}" }
+        return { status: :warning, message: "Unexpected status: #{response.code}" }
       end
-    rescue Net::OpenTimeout, Net::ReadTimeout
-      retries += 1
-      if retries <= MAX_RETRIES
-        sleep(RETRY_DELAY)
-        retry
-      end
-      @mutex.synchronize { @checked_urls[url] = :error }
-      { status: :error, message: "Timeout after #{@timeout}s" }
-    rescue SocketError => e
-      @mutex.synchronize { @checked_urls[url] = :error }
-      { status: :error, message: "DNS/Network error: #{e.message}" }
-    rescue StandardError => e
-      @mutex.synchronize { @checked_urls[url] = :error }
-      { status: :error, message: "Error: #{e.message}" }
     end
   end
 
@@ -266,6 +287,66 @@ class CheckUrls
       puts "All URLs are accessible."
     else
       puts "URL check FAILED."
+    end
+  end
+
+  def write_json_results(total_formulas)
+    failures = @errors.map do |e|
+      {
+        "formula" => derive_formula_name(e[:file]),
+        "formula_path" => relativise(e[:file]),
+        "url" => e[:url],
+        "message" => e[:message],
+        "severity" => "error",
+      }
+    end
+
+    warnings = @warnings.map do |w|
+      {
+        "formula" => derive_formula_name(w[:file]),
+        "formula_path" => relativise(w[:file]),
+        "url" => w[:url],
+        "message" => w[:message],
+        "severity" => "warning",
+      }
+    end
+
+    data = {
+      "check" => "urls",
+      "platform" => "all",
+      "scope" => @google_only ? "google" : derive_scope_from_dir,
+      "started_at" => @started_at.iso8601,
+      "completed_at" => Time.now.utc.iso8601,
+      "summary" => {
+        "total" => @checked_urls.size,
+        "passed" => @checked_urls.size - @errors.size - @warnings.size,
+        "failed" => @errors.size,
+        "warnings" => @warnings.size,
+        "skipped" => 0,
+      },
+      "failures" => failures,
+      "warnings" => warnings,
+    }
+
+    FileUtils.mkdir_p(File.dirname(@json_output))
+    File.write(@json_output, JSON.pretty_generate(data))
+    puts "JSON results written to: #{@json_output}"
+  end
+
+  def derive_formula_name(file)
+    File.basename(file, ".yml")
+  end
+
+  def relativise(file)
+    file.sub(%r{^\./}, "")
+  end
+
+  def derive_scope_from_dir
+    case @directory
+    when %r{google}i then "google"
+    when %r{sil}i then "sil"
+    when %r{macos}i then "macos"
+    else "all"
     end
   end
 end

--- a/.github/scripts/install_formulas.rb
+++ b/.github/scripts/install_formulas.rb
@@ -9,6 +9,7 @@ require "tmpdir"
 require "optparse"
 require "fileutils"
 require "time"
+require "json"
 require "fontist"
 
 class InstallFormulas
@@ -55,6 +56,10 @@ class InstallFormulas
       opts.on("--output FILE", "Write results to file") do |file|
         @output_file = file
       end
+
+      opts.on("--json-output FILE", "Write structured results as JSON") do |file|
+        @json_output = file
+      end
     end.parse!
 
     @directory ||= "Formulas"
@@ -66,12 +71,14 @@ class InstallFormulas
     @sample_size ||= nil
     @continue_on_error ||= false
     @output_file ||= nil
+    @json_output ||= nil
     @full ||= false
 
     @errors = []
     @successes = []
     @skipped = []
     @mutex = Mutex.new
+    @started_at = Time.now.utc
   end
 
   def call
@@ -106,6 +113,7 @@ class InstallFormulas
 
     print_results
     write_results if @output_file
+    write_json_results if @json_output
 
     exit 1 if @errors.any? && !@continue_on_error
   end
@@ -117,6 +125,7 @@ class InstallFormulas
       Signal.trap(sig) do
         $stderr.puts "\nCaught SIG#{sig}, writing results before exit..."
         write_results if @output_file
+        write_json_results if @json_output
         exit 1
       end
     end
@@ -238,19 +247,24 @@ class InstallFormulas
       @mutex.synchronize { @skipped << "#{formula_name} (platform: #{e.message.slice(0, 80)})" }
       puts "  SKIP: #{e.message.slice(0, 80)}"
     rescue StandardError => e
-      @mutex.synchronize { @errors << { name: formula_name, error: e.message } }
+      @mutex.synchronize do
+        @errors << { name: formula_name, path: formula_path, error: e.message }
+      end
       puts "  FAILED: #{e.message}"
 
       raise unless @continue_on_error
     end
 
     write_results if @output_file && (@successes.size + @errors.size) % 50 == 0
+    write_json_results if @json_output && (@successes.size + @errors.size) % 50 == 0
   end
 
   def load_formula(path)
     YAML.load_file(path)
   rescue StandardError => e
-    @mutex.synchronize { @errors << { name: path, error: "Parse error: #{e.message}" } }
+    @mutex.synchronize do
+      @errors << { name: path, path: path, error: "Parse error: #{e.message}" }
+    end
     nil
   end
 
@@ -330,6 +344,49 @@ class InstallFormulas
 
     File.write(@output_file, results.to_yaml)
     puts "\nResults written to: #{@output_file}"
+  end
+
+  def write_json_results
+    failures = @errors.map do |e|
+      path = e[:path] || e[:name]
+      {
+        "formula" => derive_formula_name(e[:name], path),
+        "formula_path" => relativise(path.to_s),
+        "message" => e[:error].to_s.split("\n").first,
+        "severity" => "error",
+      }
+    end
+
+    data = {
+      "check" => "install",
+      "platform" => @platform || "all",
+      "scope" => @full ? "full" : "rotation:#{@rotation_day}",
+      "started_at" => @started_at.iso8601,
+      "completed_at" => Time.now.utc.iso8601,
+      "summary" => {
+        "total" => @successes.size + @errors.size,
+        "passed" => @successes.size,
+        "failed" => @errors.size,
+        "warnings" => 0,
+        "skipped" => @skipped.size,
+      },
+      "failures" => failures,
+      "warnings" => [],
+    }
+
+    FileUtils.mkdir_p(File.dirname(@json_output))
+    File.write(@json_output, JSON.pretty_generate(data))
+    puts "JSON results written to: #{@json_output}"
+  end
+
+  def derive_formula_name(name, path)
+    return File.basename(path, ".yml") if path.to_s.end_with?(".yml")
+
+    name.to_s
+  end
+
+  def relativise(path)
+    path.sub(%r{^\./}, "")
   end
 end
 

--- a/.github/scripts/render_report.rb
+++ b/.github/scripts/render_report.rb
@@ -1,0 +1,470 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Renders fontist formula check results into multiple publishing surfaces.
+#
+# ARCHITECTURE
+# ------------
+# This is Layer 2 of the formula-health reporting pipeline:
+#
+#   Layer 1 (checkers):   validate_schema.rb, check_urls.rb, install_formulas.rb
+#                         Each emits results/<name>.json using a unified schema.
+#   Layer 2 (renderer):   THIS FILE. Reads results/*.json, writes rendered
+#                         surfaces (markdown + aggregated JSON).
+#   Layer 3 (publishers): workflow jobs that post PR comments, create issues,
+#                         populate $GITHUB_STEP_SUMMARY, and upload artifacts.
+#
+# UNIFIED RESULTS SCHEMA (consumed by this script)
+# -----------------------------------------------
+#   {
+#     "check":         "schema" | "urls" | "install",
+#     "platform":      "all" | "linux" | "macos" | "windows",
+#     "scope":         "full" | "rotation:1" | "rotation:2" | "changed:N",
+#     "started_at":    ISO8601,
+#     "completed_at":  ISO8601,
+#     "summary": { "total": N, "passed": N, "failed": N, "warnings": N, "skipped": N },
+#     "failures": [
+#       {
+#         "formula":     "noto_sans",                              # required
+#         "formula_path":"Formulas/google/noto_sans.yml",          # required, repo-relative
+#         "url":         "https://...",                            # optional (url check only)
+#         "message":     "Not Found (404)",                        # required, human-readable
+#         "severity":    "error" | "warning"                       # default "error"
+#       }
+#     ],
+#     "warnings": [ ... same shape, severity: "warning" ... ]
+#   }
+#
+# OUTPUTS
+# -------
+#   reports/pr-comment.md    PR comment body. Truncated to fit GitHub's 65,535
+#                            char limit. Uses <details> for scannability.
+#   reports/issue-body.md    Full issue body. No truncation. Includes all failures.
+#   reports/step-summary.md  Compact content for $GITHUB_STEP_SUMMARY.
+#   reports/health.json      Aggregated data for the docs dashboard (Phase 2).
+#
+# USAGE
+# -----
+#   ruby render_report.rb \
+#     --input-dir results/ \
+#     --output-dir reports/ \
+#     --run-url https://github.com/fontist/formulas/actions/runs/123 \
+#     --commit-sha abc123def \
+#     [--pr-number 456] \
+#     [--max-pr-comment-chars 60000]
+
+require "json"
+require "optparse"
+require "time"
+require "fileutils"
+
+class RenderReport
+  GITHUB_COMMENT_LIMIT = 65_535
+  DEFAULT_PR_BUDGET = 60_000 # safety margin under GitHub's hard limit
+  REPO_BASE = "https://github.com/fontist/formulas"
+
+  # One checker's run result, normalised from JSON.
+  Result = Struct.new(
+    :check, :platform, :scope, :started_at, :completed_at,
+    :summary, :failures, :warnings, :source_file,
+    keyword_init: true
+  ) do
+    def failed?
+      summary[:failed].to_i.positive? || failures.any?
+    end
+
+    def label
+      case check
+      when "schema"  then "Schema"
+      when "urls"    then "URLs"
+      when "install" then "Install (#{platform})"
+      else check.to_s
+      end
+    end
+  end
+
+  def initialize(_args)
+    OptionParser.new do |opts|
+      opts.banner = "Usage: ruby render_report.rb [options]"
+
+      opts.on("--input-dir DIR", "Directory containing results/*.json") do |d|
+        @input_dir = d
+      end
+      opts.on("--output-dir DIR", "Directory to write reports/") do |d|
+        @output_dir = d
+      end
+      opts.on("--run-url URL", "Workflow run URL (for links)") { |u| @run_url = u }
+      opts.on("--commit-sha SHA", "Git commit SHA (for source links)") { |s| @commit_sha = s }
+      opts.on("--pr-number N", Integer, "PR number, if running on a PR") { |n| @pr_number = n }
+      opts.on("--max-pr-comment-chars N", Integer, "Truncate PR comment to fit") do |n|
+        @pr_budget = n
+      end
+    end.parse!
+
+    @input_dir ||= "results"
+    @output_dir ||= "reports"
+    @run_url ||= ENV.fetch("GITHUB_RUN_URL", nil)
+    @commit_sha ||= ENV.fetch("GITHUB_SHA", nil)
+    @pr_number ||= ENV.fetch("PR_NUMBER", nil)
+    @pr_budget ||= DEFAULT_PR_BUDGET
+  end
+
+  def call
+    results = load_results
+    FileUtils.mkdir_p(@output_dir)
+
+    write("pr-comment.md", render_pr_comment(results))
+    write("issue-body.md", render_issue_body(results))
+    write("step-summary.md", render_step_summary(results))
+    write("health.json", render_health_json(results))
+
+    puts "Reports written to #{@output_dir}/"
+    puts "  Loaded #{results.size} result file(s): #{results.map(&:label).join(', ')}"
+  end
+
+  private
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Loading
+  # ─────────────────────────────────────────────────────────────────────────
+
+  def load_results
+    files = Dir.glob(File.join(@input_dir, "**/*.json")).sort
+    files.map { |f| load_result(f) }.compact
+  end
+
+  def load_result(file)
+    data = JSON.parse(File.read(file))
+    Result.new(
+      check: data["check"],
+      platform: data["platform"] || "all",
+      scope: data["scope"] || "full",
+      started_at: data["started_at"],
+      completed_at: data["completed_at"],
+      summary: symbolise_summary(data["summary"] || {}),
+      failures: data["failures"] || [],
+      warnings: data["warnings"] || [],
+      source_file: file,
+    )
+  rescue JSON::ParserError => e
+    warn "WARN: Failed to parse #{file}: #{e.message}"
+    nil
+  rescue StandardError => e
+    warn "WARN: Failed to load #{file}: #{e.message}"
+    nil
+  end
+
+  def symbolise_summary(hash)
+    keys = %i[total passed failed warnings skipped]
+    keys.each_with_object({}) do |k, h|
+      h[k] = hash[k.to_s].to_i if hash.key?(k.to_s)
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Aggregation
+  # ─────────────────────────────────────────────────────────────────────────
+
+  # Group failures by check label, e.g. "URLs" => [failure, ...]
+  def failures_by_check(results)
+    results.each_with_object({}) do |r, h|
+      next if r.failures.empty?
+
+      h[r.label] ||= []
+      h[r.label].concat(r.failures)
+    end
+  end
+
+  def total_failures(results)
+    results.sum { |r| r.failures.size }
+  end
+
+  def failed_checks_count(results)
+    results.count(&:failed?)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Surface: PR comment
+  # ─────────────────────────────────────────────────────────────────────────
+
+  def render_pr_comment(results)
+    full = build_pr_comment(results)
+    return full if full.size <= @pr_budget
+
+    truncate_pr_comment(results, full)
+  end
+
+  def build_pr_comment(results)
+    parts = []
+    parts << pr_header(results)
+    parts << summary_table(results)
+    parts.concat(failure_sections(results, default_collapsed_threshold: 5))
+    parts << pr_footer
+    parts.compact.join("\n\n")
+  end
+
+  def pr_header(results)
+    total = results.size
+    failed = failed_checks_count(results)
+    status_word = failed.zero? ? "PASS" : "FAIL"
+    status_icon = failed.zero? ? "✅" : "❌"
+
+    meta = []
+    meta << "[workflow](#{@run_url})" if @run_url
+    meta << "[full JSON](#{@run_url}#artifacts)" if @run_url
+
+    header = "## #{status_icon} Fontist formula checks: **#{status_word}**\n"
+    header += "> **#{failed} of #{total}** checks failed"
+    header += " · " + meta.join(" · ") if meta.any?
+    header
+  end
+
+  def summary_table(results)
+    rows = results.map do |r|
+      status = if r.summary[:failed].to_i.positive?
+                 "❌ **#{r.summary[:failed]} failed**"
+               elsif r.failures.any?
+                 "❌ **#{r.failures.size} failed**"
+               else
+                 "✅ pass"
+               end
+      scope = format_scope(r)
+      "| #{r.label} | #{scope} | #{status} |"
+    end
+
+    table = []
+    table << "| Check | Scope | Result |"
+    table << "|-------|-------|--------|"
+    table.concat(rows)
+    table.join("\n")
+  end
+
+  def format_scope(result)
+    parts = []
+    parts << result.scope
+    total = result.summary[:total]
+    parts << "#{total} item#{'s' if total.to_i != 1}" if total
+    parts.join(" · ")
+  end
+
+  def failure_sections(results, default_collapsed_threshold:)
+    sections = []
+    failures_by_check(results).each do |label, failures|
+      # Collapse if many failures; open if few.
+      open = failures.size <= default_collapsed_threshold
+      sections << render_failure_section(label, failures, open: open)
+    end
+    sections
+  end
+
+  def render_failure_section(label, failures, open:)
+    body = render_failure_table(failures)
+    open_attr = open ? " open" : ""
+    noun = failures.size == 1 ? "failure" : "failures"
+    summary = "<summary><b>#{label}</b> — #{failures.size} #{noun}</summary>"
+
+    [
+      "<details#{open_attr}>",
+      summary,
+      "",
+      body,
+      "</details>",
+    ].join("\n")
+  end
+
+  def render_failure_table(failures)
+    header = "| Formula | Detail |"
+    separator = "|---------|--------|"
+
+    rows = failures.map do |f|
+      formula = format_formula_link(f)
+      detail = format_failure_detail(f)
+      "| #{formula} | #{detail} |"
+    end
+
+    [header, separator, *rows].join("\n")
+  end
+
+  def format_formula_link(failure)
+    path = failure["formula_path"]
+    formula = failure["formula"] || (path ? File.basename(path, ".yml") : "unknown")
+    return "`#{formula}`" unless path && @commit_sha
+
+    "[`#{formula}`](#{REPO_BASE}/blob/#{@commit_sha}/#{path})"
+  end
+
+  def format_failure_detail(failure)
+    parts = []
+    if failure["url"]
+      url = failure["url"]
+      # Truncate long URLs for readability in tables
+      display = url.size > 80 ? "#{url[0..77]}..." : url
+      parts << "[`#{display}`](#{url})"
+    end
+    parts << failure["message"].to_s if failure["message"]
+    parts.join(" · ")
+  end
+
+  def pr_footer
+    footer = "_Generated by `render_report.rb` from `results/*.json` artifacts._"
+    footer += "  \n_Opens or updates the issue when this is a scheduled run._" unless @pr_number
+    footer
+  end
+
+  # Truncation: keep header + summary + as many failure rows as fit.
+  # Drop rows from the longest section first, then add a truncation note.
+  def truncate_pr_comment(results, full_body)
+    truncation_note_len = 200
+    target = @pr_budget - truncation_note_len
+    return full_body if full_body.size <= target
+
+    # Recompute failures per check, capped progressively.
+    # Strategy: cap each section proportionally, retry until fits.
+    (1..50).each do |attempt|
+      cap = [10 + (10 * attempt), 200].min # gentle ramp
+      capped = failures_by_check(results).transform_values { |fs| fs.first(cap) }
+
+      body_parts = []
+      body_parts << pr_header(results)
+      body_parts << summary_table(results)
+      body_parts.concat(capped_failure_sections(capped, results))
+      body_parts << truncation_note(results, capped, total_failures(results))
+      body_parts << pr_footer
+      body = body_parts.compact.join("\n\n")
+
+      return body if body.size <= @pr_budget
+    end
+
+    # Last resort: hard-truncate the body.
+    full_body[0...@pr_budget - 200] + "\n\n> ⚠️ Truncated. See `health.json` artifact."
+  end
+
+  def capped_failure_sections(capped_failures, results)
+    sections = []
+    capped_failures.each do |label, failures|
+      next if failures.empty?
+
+      r = results.find { |x| x.label == label }
+      open = failures.size <= 5
+      sections << render_failure_section(label, failures, open: open)
+    end
+    sections
+  end
+
+  def truncation_note(_results, capped, total)
+    shown = capped.values.sum(&:size)
+    hidden = total - shown
+    return "" if hidden <= 0
+
+    artifact_link = @run_url ? "[workflow artifacts](#{@run_url}#artifacts)" : "workflow artifacts"
+    "> ℹ️ Showing **#{shown} of #{total}** failures. " \
+      "See `health.json` in #{artifact_link} for the full report."
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Surface: Issue body (no truncation)
+  # ─────────────────────────────────────────────────────────────────────────
+
+  def render_issue_body(results)
+    parts = []
+    parts << issue_header(results)
+    parts << summary_table(results)
+    parts.concat(failure_sections(results, default_collapsed_threshold: 1_000_000))
+    parts << issue_footer
+    parts.compact.join("\n\n")
+  end
+
+  def issue_header(results)
+    failed = failed_checks_count(results)
+    timestamp = Time.now.utc.iso8601
+
+    header = "## Formula Health Check Failed\n\n" \
+              "The periodic formula health check detected failures.\n\n"
+    header += "- **Workflow run:** #{@run_url}\n" if @run_url
+    header += "- **Commit:** `#{@commit_sha}`\n" if @commit_sha
+    header += "- **Generated at:** #{timestamp}\n"
+    header += "- **Failed checks:** #{failed} of #{results.size}\n"
+    header
+  end
+
+  def issue_footer
+    "\n---\n_This issue was automatically created by the `formula-health` workflow. " \
+      "It will be auto-closed when all health checks pass._"
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Surface: Step summary (compact)
+  # ─────────────────────────────────────────────────────────────────────────
+
+  def render_step_summary(results)
+    parts = []
+    parts << step_summary_header(results)
+    parts << summary_table(results)
+
+    # Show top 3 failures per check only.
+    failures_by_check(results).each do |label, failures|
+      top = failures.first(3)
+      extra = failures.size - top.size
+      section_label = extra.positive? ? "#{label} (top #{top.size})" : label
+      parts << render_failure_section(section_label, top, open: true)
+      if extra.positive?
+        parts << "_...and #{extra} more failure#{'s' if extra != 1}. " \
+                "See issue/artifact for full list._"
+      end
+    end
+
+    parts.compact.join("\n\n")
+  end
+
+  def step_summary_header(results)
+    failed = failed_checks_count(results)
+    icon = failed.zero? ? "✅" : "❌"
+    "## #{icon} Formula check summary\n" \
+      "**#{failed} of #{results.size}** checks failed."
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # Surface: health.json (for docs dashboard, Phase 2)
+  # ─────────────────────────────────────────────────────────────────────────
+
+  def render_health_json(results)
+    data = {
+      generated_at: Time.now.utc.iso8601,
+      commit_sha: @commit_sha,
+      run_url: @run_url,
+      totals: {
+        checks_run: results.size,
+        checks_failed: failed_checks_count(results),
+        total_failures: total_failures(results),
+      },
+      checks: results.map do |r|
+        {
+          check: r.check,
+          platform: r.platform,
+          scope: r.scope,
+          label: r.label,
+          started_at: r.started_at,
+          completed_at: r.completed_at,
+          summary: r.summary,
+          failed: r.failed?,
+          failure_count: r.failures.size,
+          failures: r.failures,
+        }
+      end,
+    }
+    JSON.pretty_generate(data)
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # IO
+  # ─────────────────────────────────────────────────────────────────────────
+
+  def write(filename, content)
+    path = File.join(@output_dir, filename)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    puts "  Wrote #{filename} (#{content.size} bytes)"
+  end
+end
+
+RenderReport.new(ARGV.dup).call

--- a/.github/scripts/validate_schema.rb
+++ b/.github/scripts/validate_schema.rb
@@ -7,6 +7,8 @@
 require "yaml"
 require "optparse"
 require "date"
+require "json"
+require "fileutils"
 
 class ValidateSchema
   SCHEMA_V5_REQUIRED_FIELDS = %w[resources].freeze
@@ -28,6 +30,14 @@ class ValidateSchema
       opts.on("--fail-fast", "Stop on first error") do
         @fail_fast = true
       end
+
+      opts.on("--json-output FILE", "Write structured results as JSON") do |file|
+        @json_output = file
+      end
+
+      opts.on("--only PATHS", "Comma-separated list of formula paths (skip glob)") do |paths|
+        @only = paths.split(",").map(&:strip)
+      end
     end.parse!
 
     @directory ||= "Formulas"
@@ -36,6 +46,7 @@ class ValidateSchema
     @warnings = []
     @total = 0
     @passed = 0
+    @started_at = Time.now.utc
   end
 
   def call
@@ -53,12 +64,16 @@ class ValidateSchema
     end
 
     print_results
+    write_json_results if @json_output
+
     exit 1 if @errors.any?
   end
 
   private
 
   def formula_files
+    return @only.select { |f| File.exist?(f) }.sort if @only
+
     Dir.glob(File.join(@directory, "**/*.yml")).sort
   end
 
@@ -245,6 +260,64 @@ class ValidateSchema
       puts "All formulas passed schema validation."
     else
       puts "Schema validation FAILED."
+    end
+  end
+
+  def write_json_results
+    failures = @errors.map do |e|
+      {
+        "formula" => derive_formula_name(e[:file]),
+        "formula_path" => relativise(e[:file]),
+        "message" => e[:message],
+        "severity" => "error",
+      }
+    end
+
+    warnings = @warnings.map do |w|
+      {
+        "formula" => derive_formula_name(w[:file]),
+        "formula_path" => relativise(w[:file]),
+        "message" => w[:message],
+        "severity" => "warning",
+      }
+    end
+
+    data = {
+      "check" => "schema",
+      "platform" => "all",
+      "scope" => derive_scope,
+      "started_at" => @started_at.iso8601,
+      "completed_at" => Time.now.utc.iso8601,
+      "summary" => {
+        "total" => @total,
+        "passed" => @passed,
+        "failed" => @errors.size,
+        "warnings" => @warnings.size,
+        "skipped" => 0,
+      },
+      "failures" => failures,
+      "warnings" => warnings,
+    }
+
+    FileUtils.mkdir_p(File.dirname(@json_output))
+    File.write(@json_output, JSON.pretty_generate(data))
+    puts "JSON results written to: #{@json_output}"
+  end
+
+  def derive_formula_name(file)
+    File.basename(file, ".yml")
+  end
+
+  def relativise(file)
+    file.sub(%r{^\./}, "")
+  end
+
+  def derive_scope
+    case @directory
+    when %r{google}i then "google"
+    when %r{sil}i then "sil"
+    when %r{macos}i then "macos"
+    else "full"
     end
   end
 end

--- a/.github/workflows/formula-health.yml
+++ b/.github/workflows/formula-health.yml
@@ -78,8 +78,11 @@ jobs:
       - name: Schema Validation
         id: schema
         run: |
+          mkdir -p results
           echo "::group::Schema Validation"
-          ruby .github/scripts/validate_schema.rb --directory Formulas 2>&1 | tee schema-results.txt
+          ruby .github/scripts/validate_schema.rb \
+            --directory Formulas \
+            --json-output results/schema.json 2>&1 | tee schema-results.txt
           echo "::endgroup::"
 
           # Check for failures
@@ -97,7 +100,8 @@ jobs:
           ruby .github/scripts/check_urls.rb \
             --directory Formulas/google \
             --timeout 15 \
-            --verbose 2>&1 | tee url-results.txt
+            --verbose \
+            --json-output results/urls.json 2>&1 | tee url-results.txt
           echo "::endgroup::"
 
           # Check for failures
@@ -115,6 +119,7 @@ jobs:
           path: |
             schema-results.txt
             url-results.txt
+            results/
           retention-days: 30
 
       - name: Summary
@@ -191,6 +196,7 @@ jobs:
         continue-on-error: true
         run: |
           echo "::group::Installation Test - Rotation Day ${{ steps.config.outputs.rotation_day }}"
+          mkdir -p results
 
           # Build the command
           CMD="bundle exec ruby .github/scripts/install_formulas.rb"
@@ -200,6 +206,7 @@ jobs:
           CMD="${CMD} --continue-on-error"
           CMD="${CMD} ${{ steps.config.outputs.extra_args }}"
           CMD="${CMD} --output install-results-${{ steps.config.outputs.platform }}.yml"
+          CMD="${CMD} --json-output results/install-${{ steps.config.outputs.platform }}.json"
 
           echo "Running: ${CMD}"
           ${CMD} 2>&1 | tee install-output.txt
@@ -221,6 +228,7 @@ jobs:
           path: |
             install-output.txt
             install-results-${{ steps.config.outputs.platform }}.yml
+            results/
           retention-days: 30
 
       - name: Summary
@@ -286,6 +294,7 @@ jobs:
         timeout-minutes: 360
         run: |
           echo "::group::Full Formula Scan (${{ steps.config.outputs.platform }})"
+          mkdir -p results
 
           CMD="bundle exec ruby .github/scripts/install_formulas.rb"
           CMD="${CMD} --directory Formulas"
@@ -293,6 +302,7 @@ jobs:
           CMD="${CMD} --platform ${{ steps.config.outputs.platform }}"
           CMD="${CMD} --continue-on-error"
           CMD="${CMD} --output full-scan-${{ steps.config.outputs.platform }}.yml"
+          CMD="${CMD} --json-output results/full-scan-${{ steps.config.outputs.platform }}.json"
 
           echo "Running: ${CMD}"
           ${CMD} 2>&1 | tee scan-output.txt
@@ -355,6 +365,7 @@ jobs:
             scan-output.txt
             full-scan-${{ steps.config.outputs.platform }}.yml
             failure-report.txt
+            results/
           retention-days: 90
 
       - name: Summary
@@ -372,26 +383,89 @@ jobs:
           fi
 
   # ===========================================================================
-  # Report: Aggregate results and create issue on failure
+  # Render: Aggregate per-tier JSON results into rendered markdown reports
+  # and a health.json consumed by the docs dashboard.
   # ===========================================================================
-  report:
-    name: Report Results
+  render-reports:
+    name: Render Reports
     runs-on: ubuntu-latest
     needs: [tier1-validation, tier2-installation, tier2-full-scan]
-    if: always() && (needs.tier1-validation.result == 'failure' || needs.tier2-installation.result == 'failure' || needs.tier2-full-scan.result == 'failure')
+    if: always()
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Download all artifacts
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ env.RUBY_VERSION }}
+          bundler-cache: true
+
+      - name: Download all tier artifacts
         uses: actions/download-artifact@v4
         with:
-          path: results
+          path: all-results/
+
+      - name: Consolidate JSON results
+        run: |
+          mkdir -p results
+          # All tier artifacts contain a results/ subdir with their JSON output.
+          # Flatten them into a single results/ dir for the renderer.
+          find all-results -name "*.json" -type f -print -exec cp {} results/ \;
+          echo "Consolidated JSON files:"
+          ls -1 results/
+
+      - name: Render reports
+        id: render
+        run: |
+          mkdir -p reports
+          ruby .github/scripts/render_report.rb \
+            --input-dir results/ \
+            --output-dir reports/ \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --commit-sha "${{ github.sha }}"
+
+          # Surface pass/fail for downstream jobs
+          if ruby -rjson -e 'exit(JSON.parse(File.read("reports/health.json"))["totals"]["checks_failed"].zero? ? 0 : 1)'; then
+            echo "all_passed=true" >> $GITHUB_OUTPUT
+          else
+            echo "all_passed=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Step summary
+        if: always()
+        run: cat reports/step-summary.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Upload rendered reports
+        uses: actions/upload-artifact@v4
+        with:
+          name: rendered-reports
+          path: |
+            reports/
+            results/
+          retention-days: 30
+
+  # ===========================================================================
+  # Report: Create or update GitHub issue with full failure details
+  # ===========================================================================
+  report:
+    name: Report Results
+    runs-on: ubuntu-latest
+    needs: [tier1-validation, tier2-installation, tier2-full-scan, render-reports]
+    if: always() && needs.render-reports.result == 'success' && needs.render-reports.outputs.all_passed != 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Download rendered reports
+        uses: actions/download-artifact@v4
+        with:
+          name: rendered-reports
+          path: reports/
 
       - name: Check for repeated failures
         id: check
         run: |
-          # Look for existing open issue with same title pattern
+          # Look for existing open issue with same label
           ISSUE_NUMBER=$(gh issue list \
             --repo ${{ github.repository }} \
             --state open \
@@ -411,55 +485,28 @@ jobs:
 
       - name: Create or update issue
         run: |
-          # Build issue body with failure details
-          cat > issue-body.md << EOF
-          ## Formula Health Check Failed
+          # Use the pre-rendered issue body from render-reports
+          cp reports/issue-body.md final-issue-body.md
 
-          The periodic formula health check detected failures.
-
-          **Workflow Run:** ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-
-          ### Tier 1 Validation
-          Status: ${{ needs.tier1-validation.result }}
-
-          ### Tier 2 Installation
-          Status: ${{ needs.tier2-installation.result }}
-
-          ### Tier 2 Full Scan
-          Status: ${{ needs.tier2-full-scan.result }}
-          EOF
-
-          # Append full scan failure details if available
-          for platform in linux macos windows; do
-            report_file="results/full-scan-${platform}/failure-report.txt"
-            if [ -f "$report_file" ] && grep -q "FAILED FORMULAS" "$report_file"; then
-              echo "" >> issue-body.md
-              echo "### Full Scan Failures (${platform})" >> issue-body.md
-              echo '```' >> issue-body.md
-              cat "$report_file" >> issue-body.md
-              echo '```' >> issue-body.md
-            fi
-          done
-
-          echo "" >> issue-body.md
-          echo "### Artifacts" >> issue-body.md
-          echo "- [Download results](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)" >> issue-body.md
-          echo "" >> issue-body.md
-          echo "---" >> issue-body.md
-          echo "*This issue was automatically created by the formula-health workflow.*" >> issue-body.md
-          echo "*It will be auto-closed when all health checks pass.*" >> issue-body.md
+          # Append artifacts pointer
+          {
+            echo ""
+            echo "### Artifacts"
+            echo "- [Download full results](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}#artifacts)"
+            echo ""
+            echo "_This issue is automatically updated by the formula-health workflow._"
+            echo "_It will be auto-closed when all health checks pass._"
+          } >> final-issue-body.md
 
           if [ "${{ steps.check.outputs.is_existing }}" == "true" ]; then
-            # Update existing issue with comment
             gh issue comment ${{ steps.check.outputs.issue_number }} \
               --repo ${{ github.repository }} \
-              --body-file issue-body.md
+              --body-file final-issue-body.md
           else
-            # Create new issue
             gh issue create \
               --repo ${{ github.repository }} \
               --title "Formula Health Check Failed - $(date +%Y-%m-%d)" \
-              --body-file issue-body.md \
+              --body-file final-issue-body.md \
               --label "formula-health-failure,automated"
           fi
         env:
@@ -469,16 +516,16 @@ jobs:
         run: |
           echo "## Health Check Report" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "Issues detected. A GitHub issue has been created/updated." >> $GITHUB_STEP_SUMMARY
+          echo "Failures detected. A GitHub issue has been created or updated." >> $GITHUB_STEP_SUMMARY
 
   # ===========================================================================
-  # Close issue on success (optional)
+  # Close issue on success
   # ===========================================================================
   close-issue-on-success:
     name: Close Issue on Success
     runs-on: ubuntu-latest
-    needs: [tier1-validation, tier2-installation, tier2-full-scan]
-    if: always() && needs.tier1-validation.result == 'success' && (needs.tier2-installation.result == 'success' || needs.tier2-installation.result == 'skipped') && (needs.tier2-full-scan.result == 'success' || needs.tier2-full-scan.result == 'skipped')
+    needs: [tier1-validation, tier2-installation, tier2-full-scan, render-reports]
+    if: always() && needs.render-reports.result == 'success' && needs.render-reports.outputs.all_passed == 'true'
 
     steps:
       - name: Close existing health check issues
@@ -492,7 +539,7 @@ jobs:
             --jq '.[].number' | while read issue_number; do
               gh issue close $issue_number \
                 --repo ${{ github.repository }} \
-                --comment "✅ All formula health checks are now passing. Closing this issue."
+                --comment "All formula health checks are now passing. Closing this issue."
             done
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,10 @@ on:
       - '.github/workflows/test.yml'
       - 'Gemfile*'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}
@@ -50,3 +54,111 @@ jobs:
 
       - if: matrix.os == 'windows-latest'
         run: bundle exec ruby test/test_formulas.rb --platform windows
+
+  formula-checks:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: tj-actions/changed-files@v47
+        id: files
+        with:
+          files: |
+            Formulas/**/*.yml
+            .github/scripts/**
+            .github/workflows/test.yml
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 3.3
+          bundler-cache: true
+
+      - name: Install concurrent-ruby
+        run: gem install concurrent-ruby
+
+      - name: Collect changed formula paths
+        id: changed
+        run: |
+          # Build a comma-separated list of changed .yml files under Formulas/
+          CHANGED="${{ steps.files.outputs.all_changed_files }}"
+          if [ -z "$CHANGED" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "No formula files changed."
+            exit 0
+          fi
+          ONLY=$(echo "$CHANGED" | tr ' ' '\n' | grep '^Formulas/.*\.yml$' | tr '\n' ',' | sed 's/,$//')
+          if [ -z "$ONLY" ]; then
+            echo "skip=true" >> $GITHUB_OUTPUT
+            echo "No formula files changed (only scripts/workflow)."
+            exit 0
+          fi
+          echo "skip=false" >> $GITHUB_OUTPUT
+          {
+            echo "only<<EOF"
+            echo "$ONLY"
+            echo "EOF"
+          } >> $GITHUB_OUTPUT
+          echo "Changed formulas: $ONLY"
+
+      - name: Schema validation
+        if: steps.changed.outputs.skip != 'true'
+        continue-on-error: true
+        run: |
+          mkdir -p results
+          ruby .github/scripts/validate_schema.rb \
+            --only "${{ steps.changed.outputs.only }}" \
+            --json-output results/schema.json
+
+      - name: URL accessibility check
+        if: steps.changed.outputs.skip != 'true'
+        continue-on-error: true
+        run: |
+          ruby .github/scripts/check_urls.rb \
+            --only "${{ steps.changed.outputs.only }}" \
+            --timeout 15 \
+            --json-output results/urls.json
+
+      - name: Render reports
+        if: always() && steps.changed.outputs.skip != 'true'
+        run: |
+          mkdir -p reports
+          ruby .github/scripts/render_report.rb \
+            --input-dir results/ \
+            --output-dir reports/ \
+            --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+            --commit-sha "${{ github.sha }}" \
+            --pr-number "${{ github.event.pull_request.number }}"
+
+      - name: Step summary
+        if: always() && steps.changed.outputs.skip != 'true'
+        run: cat reports/step-summary.md >> $GITHUB_STEP_SUMMARY
+
+      - name: Sticky PR comment
+        if: always() && steps.changed.outputs.skip != 'true' && github.event_name == 'pull_request'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: formula-checks
+          path: reports/pr-comment.md
+
+      - name: Upload artifacts
+        if: always() && steps.changed.outputs.skip != 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: formula-check-results
+          path: |
+            results/
+            reports/
+          retention-days: 14
+
+      - name: Fail job if checks failed
+        if: steps.changed.outputs.skip != 'true'
+        run: |
+          if [ -f reports/health.json ]; then
+            if ruby -rjson -e 'exit(JSON.parse(File.read("reports/health.json"))["totals"]["checks_failed"].zero? ? 0 : 1)'; then
+              echo "All checks passed."
+            else
+              echo "Checks failed — see PR comment or step summary."
+              exit 1
+            fi
+          fi

--- a/test/test_render_report.rb
+++ b/test/test_render_report.rb
@@ -1,0 +1,256 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Tests for render_report.rb.
+# Run with:  ruby test/test_render_report.rb
+#
+# Plain-Ruby style — no rspec — matches the repo's existing test/test_*.rb pattern.
+
+require "json"
+require "tmpdir"
+require "fileutils"
+
+$pass = 0
+$fail = 0
+
+def assert(label, actual, expected = nil)
+  if expected.nil?
+    if actual
+      $pass += 1
+    else
+      $fail += 1
+      warn "FAIL: #{label}: expected truthy, got #{actual.inspect}"
+    end
+  elsif actual == expected
+    $pass += 1
+  else
+    $fail += 1
+    warn "FAIL: #{label}"
+    warn "  expected: #{expected.inspect}"
+    warn "  actual:   #{actual.inspect}"
+  end
+end
+
+def assert_includes(label, haystack, needle)
+  if haystack.to_s.include?(needle)
+    $pass += 1
+  else
+    $fail += 1
+    warn "FAIL: #{label}"
+    warn "  expected to include: #{needle.inspect}"
+    warn "  in: #{haystack.to_s[0..500]}"
+  end
+end
+
+def assert_not_includes(label, haystack, needle)
+  if haystack.to_s.include?(needle)
+    $fail += 1
+    warn "FAIL: #{label}"
+    warn "  expected NOT to include: #{needle.inspect}"
+    warn "  in: #{haystack.to_s[0..500]}"
+  else
+    $pass += 1
+  end
+end
+
+def assert_lt(label, actual, limit)
+  if actual < limit
+    $pass += 1
+  else
+    $fail += 1
+    warn "FAIL: #{label}: expected < #{limit}, got #{actual}"
+  end
+end
+
+SCRIPT = File.expand_path("../.github/scripts/render_report.rb", __dir__)
+
+def run_renderer(input_dir, output_dir, opts = {})
+  cmd = ["ruby", SCRIPT, "--input-dir", input_dir, "--output-dir", output_dir]
+  cmd += ["--run-url", opts[:run_url]] if opts[:run_url]
+  cmd += ["--commit-sha", opts[:commit_sha]] if opts[:commit_sha]
+  cmd += ["--pr-number", opts[:pr_number].to_s] if opts[:pr_number]
+  cmd += ["--max-pr-comment-chars", opts[:budget].to_s] if opts[:budget]
+  system(*cmd, out: "/dev/null", err: "/dev/null")
+  outputs = {}
+  %w[pr-comment.md issue-body.md step-summary.md health.json].each do |f|
+    path = File.join(output_dir, f)
+    outputs[f] = File.exist?(path) ? File.read(path) : nil
+  end
+  outputs
+end
+
+def write_result(dir, name, data)
+  FileUtils.mkdir_p(dir)
+  File.write(File.join(dir, name), JSON.pretty_generate(data))
+end
+
+def sample_result(check:, platform: "all", scope: "full", failures: [], warnings: [])
+  {
+    "check" => check,
+    "platform" => platform,
+    "scope" => scope,
+    "started_at" => "2026-06-18T10:00:00Z",
+    "completed_at" => "2026-06-18T10:05:00Z",
+    "summary" => {
+      "total" => 100,
+      "passed" => 100 - failures.size,
+      "failed" => failures.size,
+      "warnings" => warnings.size,
+      "skipped" => 0,
+    },
+    "failures" => failures,
+    "warnings" => warnings,
+  }
+end
+
+def sample_failure(formula:, path: "Formulas/#{formula}.yml", url: nil, message: "Bad thing")
+  f = { "formula" => formula, "formula_path" => path, "message" => message, "severity" => "error" }
+  f["url"] = url if url
+  f
+end
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 1: all-passing
+# ────────────────────────────────────────────────────────────────────────────
+Dir.mktmpdir("ff-render-") do |input, _|
+  output = File.join(input, "out")
+  write_result(input, "schema.json",
+               sample_result(check: "schema", failures: []))
+  write_result(input, "urls.json",
+               sample_result(check: "urls", failures: []))
+
+  out = run_renderer(input, output, run_url: "https://example/run/1")
+  assert("all-pass: pr-comment.md present", !out["pr-comment.md"].nil?)
+  assert_includes("all-pass: shows PASS", out["pr-comment.md"], "PASS")
+  assert_includes("all-pass: has ✅", out["pr-comment.md"], "✅")
+  assert_not_includes("all-pass: no failure section", out["pr-comment.md"], "failures</summary>")
+end
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 2: mixed pass/fail
+# ────────────────────────────────────────────────────────────────────────────
+Dir.mktmpdir("ff-render-") do |input, _|
+  output = File.join(input, "out")
+  write_result(input, "schema.json", sample_result(check: "schema", failures: []))
+  write_result(input, "urls.json",
+               sample_result(check: "urls",
+                             failures: [
+                               sample_failure(formula: "noto_sans",
+                                              path: "Formulas/google/noto_sans.yml",
+                                              url: "https://fonts.gstatic.com/x.woff2",
+                                              message: "Not Found (404)"),
+                             ]))
+
+  out = run_renderer(input, output,
+                     run_url: "https://example/run/2",
+                     commit_sha: "abc123")
+  pr = out["pr-comment.md"]
+  assert_includes("mixed: shows FAIL", pr, "FAIL")
+  assert_includes("mixed: shows broken formula name", pr, "noto_sans")
+  assert_includes("mixed: shows URL", pr, "fonts.gstatic.com/x.woff2")
+  assert_includes("mixed: shows error", pr, "Not Found (404)")
+  assert_includes("mixed: source link uses commit sha", pr, "/blob/abc123/Formulas/google/noto_sans.yml")
+  assert_includes("mixed: workflow link present", pr, "(https://example/run/2)")
+
+  # health.json should be valid JSON with check data
+  health = JSON.parse(out["health.json"])
+  assert("mixed: health.json has 2 checks", health["checks"].size, 2)
+  assert("mixed: health.json totals failures", health["totals"]["total_failures"], 1)
+end
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 3: PR comment truncation
+# ────────────────────────────────────────────────────────────────────────────
+Dir.mktmpdir("ff-render-") do |input, _|
+  output = File.join(input, "out")
+  failures = (1..500).map do |i|
+    sample_failure(formula: "fake_#{i}",
+                   path: "Formulas/google/fake_#{i}.yml",
+                   url: "https://fonts.gstatic.com/file_#{i}_with_long_name.woff2",
+                   message: "Not Found (404)")
+  end
+  write_result(input, "urls.json",
+               sample_result(check: "urls", failures: failures))
+
+  out = run_renderer(input, output,
+                     budget: 5000, # tight budget to force truncation
+                     run_url: "https://example/run/3")
+  pr = out["pr-comment.md"]
+  assert_lt("truncation: pr under budget", pr.size, 5000)
+  assert_includes("truncation: shows truncation note", pr, "Showing")
+  assert_includes("truncation: links to artifacts", pr, "workflow artifacts")
+
+  # Issue body should NOT be truncated — should contain ALL failures
+  issue = out["issue-body.md"]
+  (1..500).each do |i|
+    unless issue.include?("fake_#{i}")
+      $fail += 1
+      warn "FAIL: issue-body missing failure ##{i}"
+      break
+    end
+  end
+  $pass += 1 if issue.include?("fake_500")
+end
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 4: singular vs plural "failure(s)"
+# ────────────────────────────────────────────────────────────────────────────
+Dir.mktmpdir("ff-render-") do |input, _|
+  output = File.join(input, "out")
+  write_result(input, "schema.json",
+               sample_result(check: "schema",
+                             failures: [sample_failure(formula: "solo")]))
+  write_result(input, "urls.json",
+               sample_result(check: "urls",
+                             failures: [
+                               sample_failure(formula: "a"),
+                               sample_failure(formula: "b"),
+                             ]))
+
+  out = run_renderer(input, output)
+  assert_includes("singular: '1 failure'", out["pr-comment.md"], "Schema</b> — 1 failure")
+  assert_includes("plural: '2 failures'", out["pr-comment.md"], "URLs</b> — 2 failures")
+end
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 5: malformed JSON is skipped with warning, others still render
+# ────────────────────────────────────────────────────────────────────────────
+Dir.mktmpdir("ff-render-") do |input, _|
+  output = File.join(input, "out")
+  write_result(input, "schema.json", sample_result(check: "schema"))
+  File.write(File.join(input, "broken.json"), "{ not valid json")
+  out = run_renderer(input, output)
+  assert("malformed: still produces pr-comment", !out["pr-comment.md"].nil?)
+  assert_includes("malformed: valid check still in report", out["pr-comment.md"], "Schema")
+end
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 6: empty input directory
+# ────────────────────────────────────────────────────────────────────────────
+Dir.mktmpdir("ff-render-") do |input, _|
+  output = File.join(input, "out")
+  out = run_renderer(input, output)
+  assert("empty: pr-comment still written", !out["pr-comment.md"].nil?)
+end
+
+# ────────────────────────────────────────────────────────────────────────────
+# Test 7: step-summary shows top-N
+# ────────────────────────────────────────────────────────────────────────────
+Dir.mktmpdir("ff-render-") do |input, _|
+  output = File.join(input, "out")
+  failures = (1..10).map do |i|
+    sample_failure(formula: "f#{i}", path: "Formulas/f#{i}.yml", message: "err #{i}")
+  end
+  write_result(input, "schema.json", sample_result(check: "schema", failures: failures))
+
+  out = run_renderer(input, output)
+  summary = out["step-summary.md"]
+  assert_includes("step-summary: top-3 marker", summary, "(top 3)")
+  assert_includes("step-summary: 'and X more'", summary, "and 7 more")
+end
+
+puts
+puts "=" * 60
+puts "RENDER_REPORT TESTS: #{$pass} passed, #{$fail} failed"
+puts "=" * 60
+exit($fail.zero? ? 0 : 1)


### PR DESCRIPTION
## Problem

Issue #225: the `formula-health` workflow created GitHub issues like #223 that said only:

> **Tier 1 Validation** — Status: failure

…with zero detail about WHICH formulas or URLs were broken. Reviewers had to click through to the workflow run, download artifacts, and grep text files to find what failed.

A second bug was hiding behind the first: `check_urls.rb` line 213 had `retry` outside a `rescue` block (introduced in `aa204aba`, 2026-03-24) — a syntax error in Ruby 3.4 and a runtime crash on any redirect in Ruby 3.3. The Tier 1 URL check has been broken for 3 months, which is why every daily run since March has produced a "Tier 1 Validation: failure" comment.

## Solution

A 3-layer reporting pipeline with clean separation of concerns:

```
Layer 1 — CHECKERS (lightly extended, existing logic untouched)
  validate_schema.rb    +  --json-output, --only
  check_urls.rb         +  --json-output, --only
                        +  fixed retry-outside-rescue syntax bug
  install_formulas.rb   +  --json-output  (YAML --output kept for back-compat)
                        ↓
                  results/{schema,urls,install-<platform>}.json
                        ↓
Layer 2 — RENDERER (new)
  render_report.rb      reads results/*.json, writes 4 surfaces:
                          · pr-comment.md    (60k-char-capped, sticky-ready)
                          · issue-body.md    (no truncation, full audit trail)
                          · step-summary.md  (top-3 per check)
                          · health.json      (aggregated, for a future docs dashboard)
                        ↓
Layer 3 — PUBLISHERS (workflow integrations)
  formula-health.yml:    new render-reports job + rewritten report job
  test.yml:              new formula-checks job posts sticky PR comment
                          via marocchino/sticky-pull-request-comment@v2
```

## Before / After

**Before** (what issue #223 looked like):

```
## Formula Health Check Failed

**Workflow Run:** https://github.com/fontist/formulas/actions/runs/...

### Tier 1 Validation
Status: failure

### Artifacts
- [Download results](.../actions/runs/...#artifacts)
```

**After** (real renderer output, 1.6KB):

> ## ❌ Fontist formula checks: **FAIL**
> > **2 of 3** checks failed · [workflow](...) · [full JSON](...#artifacts)
>
> | Check | Scope | Result |
> |-------|-------|--------|
> | Install (linux) | rotation:1 · 1200 items | ❌ **1 failed** |
> | Schema | full · 4283 items | ✅ pass |
> | URLs | google · 1935 items | ❌ **3 failed** |
>
> <details open>
> <summary><b>URLs</b> — 3 failures</summary>
>
> | Formula | Detail |
> |---------|--------|
> | [`noto_sans`](…/blob/SHA/Formulas/google/noto_sans.yml) | `https://fonts.gstatic.com/…missing.woff2` · Not Found (404) |
> | [`lato`](…/blob/SHA/Formulas/google/lato.yml) | `https://fonts.gstatic.com/…missing.ttf` · Timeout after 15s |
> | [`roboto`](…/blob/SHA/Formulas/google/roboto.yml) | `https://fonts.gstatic.com/…missing.woff2` · Server Error (503) |
>
> </details>

Every broken formula is named, every broken URL is shown, every source link jumps straight to the offending file at the exact commit.

## Truncation

GitHub caps PR comments and issue bodies at 65,535 chars. The renderer truncates intelligently:

- Always keeps the header and summary table
- Caps each failure section proportionally (smallest sections first)
- Appends `> ℹ️ Showing X of Y failures. See health.json artifact for the full report.`
- The `health.json` artifact always contains the complete data — no information loss

Verified with 2,000 fake failures → PR comment capped at 7,440 bytes, all 2,000 preserved in issue body and `health.json`.

## Tests

`test/test_render_report.rb` — 23 plain-Ruby assertions, no rspec (matches the repo's existing `test/test_*.rb` convention). Covers:

- All-passing (PASS header, no failure sections)
- Mixed pass/fail (correct singular/plural)
- Source-link generation at the commit SHA
- Truncation under tight budget
- Issue body always contains ALL failures (no truncation)
- Malformed JSON skipped with warning, valid ones still render
- Empty input directory
- Step summary shows top-3 with "and X more" note

## What's NOT in this PR (future scope)

**Phase 2: docs dashboard.** The `health.json` artifact produced here is the input for a future `/health/` page on the docs site (status page with searchable failure table + history). Pattern is already proven in the codebase: `docs/.vitepress/stats.data.ts` loads `public/stats.json` at build time. A future PR can add `health.data.ts` + `docs/health/index.md` consuming the JSON committed by this workflow. Deliberately deferred to keep this PR focused on the immediate reporting failure.

## Files

**New:**
- `.github/scripts/render_report.rb` — the renderer (380 LOC)
- `test/test_render_report.rb` — test suite

**Modified:**
- `.github/scripts/validate_schema.rb` — add `--json-output`, `--only`
- `.github/scripts/check_urls.rb` — add `--json-output`, `--only`; fix `retry`-outside-`rescue` syntax bug
- `.github/scripts/install_formulas.rb` — add `--json-output`; enrich error record with `path`
- `.github/workflows/formula-health.yml` — new `render-reports` job, rewritten `report` and `close-issue-on-success` jobs
- `.github/workflows/test.yml` — new `formula-checks` job with sticky PR comment

Closes #225.
