### PR TITLE
fix(docs): eliminate slash flash on browse navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@
 .rubocop-*
 CLAUDE.md
 
+# Local planning artifacts — never commit
+TODO*
+**/TODO*
+

--- a/docs/.vitepress/theme/FormulaBrowser.vue
+++ b/docs/.vitepress/theme/FormulaBrowser.vue
@@ -7,6 +7,7 @@ const formulasData = ref([])
 const searchQuery = ref('')
 const selectedLicenses = ref(['all'])
 const selectedSources = ref(['all'])
+const basePath = import.meta.env.BASE_URL || '/'
 
 const licenseOptions = [
   { value: 'all', label: 'All Licenses', icon: 'all', count: 0 },
@@ -211,8 +212,9 @@ function goToFormula(slug) {
   // "Page not found" 404 even though the SSR HTML exists on the server.
   // Bypass SPA routing for formula clicks — full page load fetches the
   // correct HTML which loads the correct app chunk for that formula's batch.
-  const basePath = import.meta.env.BASE_URL || '/'
-  window.location.href = `${basePath}browse/${slug}/`
+  // No trailing slash: cleanUrls:true route map expects /browse/foo, and
+  // GitHub Pages serves /browse/foo/index.html for either form.
+  window.location.href = `${basePath}browse/${slug}`
 }
 
 function toggleLicense(value) {
@@ -266,7 +268,7 @@ function toggleSource(value) {
           <div v-for="letter in activeLetters" :key="letter" :id="'letter-' + letter" class="letter-group">
             <h3 class="letter-heading">{{ letter }}</h3>
             <div class="formula-items">
-              <a v-for="f in groupedFormulas[letter]" :key="f.slug" :href="f.slug + '/'" class="formula-item" @click.stop.prevent="goToFormula(f.slug)">
+              <a v-for="f in groupedFormulas[letter]" :key="f.slug" :href="`${basePath}browse/${f.slug}`" class="formula-item" @click.stop.prevent="goToFormula(f.slug)">
                 <div class="formula-main">
                   <span class="formula-name">{{ f.name }}</span>
                   <span class="formula-key">{{ f.formulaName }}</span>

--- a/docs/index.md
+++ b/docs/index.md
@@ -87,7 +87,9 @@ function goToFormula(slug) {
   // router manifest only knows about its own pages. SPA navigation from
   // the homepage to a formula in a different batch 404s. Force a full page
   // load so the server sends the correct HTML with the correct app chunk.
-  window.location.href = `${basePath}browse/${slug}/`
+  // No trailing slash: cleanUrls:true route map expects /browse/foo, and
+  // GitHub Pages serves /browse/foo/index.html for either form.
+  window.location.href = `${basePath}browse/${slug}`
 }
 
 function getSourceBadge(f) {
@@ -125,7 +127,7 @@ function onKeydown(e) {
   } else if (e.key === 'Enter') {
     e.preventDefault()
     if (selectedIndex.value >= 0) {
-      window.location.href = `${basePath}browse/${results[selectedIndex.value].slug}/`
+      window.location.href = `${basePath}browse/${results[selectedIndex.value].slug}`
     } else {
       handleSearch(e)
     }
@@ -164,7 +166,7 @@ watch(searchQuery, (val) => {
       <a
         v-for="(item, idx) in autocompleteResults"
         :key="item.slug"
-        :href="basePath + 'browse/' + item.slug + '/'"
+        :href="basePath + 'browse/' + item.slug"
         :class="getItemClass(idx)"
         @mouseover="selectedIndex = idx"
         @click.stop.prevent="goToFormula(item.slug)"


### PR DESCRIPTION
## Problem

When clicking a search filter result on `/browse/` or the homepage autocomplete, the URL bar briefly showed `/formulas/browse/foo/` (with trailing slash) then flashed to `/formulas/browse/foo` (no slash).

## Root cause

Mismatch between what we navigate to and what VitePress's route map expects:

- `cleanUrls: true` ([config.ts:33](file:///docs/.vitepress/config.ts#L33)) generates a route map with URLs like `/browse/foo` (no trailing slash, no `.html`)
- [build.js](file:///docs/build.js) rewrites `foo.html` → `foo/index.html` so GitHub Pages serves `/browse/foo/` as well
- When user clicks → `goToFormula` set `window.location.href = '/formulas/browse/foo/'`
- Server serves the page ✓
- VitePress client hydrates, sees URL `/browse/foo/`, looks up route map → **mismatch** (map has `/browse/foo`)
- VitePress calls `router.replace()` to normalize → URL bar flashes

## Fix

Drop the trailing slash from navigation. Per [VitePress routing docs](https://vitepress.dev/guide/routing), GitHub Pages supports clean URLs — it serves `/browse/foo/index.html` for **both** `/browse/foo/` and `/browse/foo`.

### Files changed

**[docs/index.md](file:///docs/index.md)** — 3 sites:
- `goToFormula()` body (line 90)
- Keyboard Enter handler (line 128)
- `<a>` href in autocomplete dropdown (line 167)

**[docs/.vitepress/theme/FormulaBrowser.vue](file:///docs/.vitepress/theme/FormulaBrowser.vue)** — 2 sites:
- `goToFormula()` body (line 215) — also hoisted `basePath` to top-level script setup
- `<a>` href in result list (line 269) — also fixed relative `f.slug + '/'` → absolute `` `${basePath}browse/${f.slug}` ``

## Bonus wins

1. **Consistency** — homepage `<a>` was already absolute, FormulaBrowser was relative. Now both absolute.
2. **SEO** — `transformHead` in [config.ts:125-128](file:///docs/.vitepress/config.ts#L125-L128) already emitted canonical URLs without trailing slash. Actual URLs now match canonical.
3. **Backward compat** — old bookmarks `/browse/foo/` still work (GitHub Pages serves either form).

## Verification

- Dev server starts cleanly with the modified Vue file
- Browse page loads
- Click any formula → URL bar shows `/browse/foo` (no slash), no flash
- Paste old URL `/browse/foo/` directly → still loads (server serves both)

## Bundled commit

Includes `chore: ignore local TODO planning artifacts` — adds `TODO*` to `.gitignore` so local planning files don't accidentally land in commits. Independent housekeeping change bundled here to avoid a separate PR for a 4-line gitignore tweak.
