### PR TITLE
feat(ci): surface archive-sync failures in PR body

### DIFF
--- a/.github/workflows/archive-sync.yml
+++ b/.github/workflows/archive-sync.yml
@@ -90,12 +90,15 @@ jobs:
             DRY_RUN="--dry-run"
           fi
 
+          mkdir -p results
           # Process each URL in the chunk
           echo "$CHUNK_URLS" | ruby -rjson -e '
             urls = JSON.parse(STDIN.read)
             urls.each { |u| puts u }
           ' | while read -r url; do
-            ruby process/archive_fonts.rb archive "$url" $DRY_RUN --registry process/archive_registry.yml
+            ruby process/archive_fonts.rb archive "$url" $DRY_RUN \
+              --registry process/archive_registry.yml \
+              --json-output results/chunk-${{ matrix.index }}.jsonl
           done
 
       - name: Upload formula changes
@@ -105,6 +108,7 @@ jobs:
           path: |
             Formulas/
             process/archive_registry.yml
+            results/
           retention-days: 1
 
   collect:
@@ -124,6 +128,7 @@ jobs:
 
       - name: Merge formula changes
         run: |
+          mkdir -p all-results
           for chunk_dir in chunks/chunk-*/; do
             if [ -d "$chunk_dir" ]; then
               echo "Merging from $chunk_dir"
@@ -135,8 +140,31 @@ jobs:
               if [ -f "$chunk_dir/process/archive_registry.yml" ]; then
                 cp "$chunk_dir/process/archive_registry.yml" process/archive_registry.yml
               fi
+              # Collect JSONL results
+              if [ -d "$chunk_dir/results" ]; then
+                cp "$chunk_dir/results/"*.jsonl all-results/ 2>/dev/null || true
+              fi
             fi
           done
+
+      - name: Generate archive report
+        if: always()
+        run: |
+          if [ -d all-results ] && ls all-results/*.jsonl 1>/dev/null 2>&1; then
+            mkdir -p results reports
+            cp all-results/*.jsonl results/
+            ruby process/archive_fonts.rb report \
+              --input-dir results \
+              --output results/archive.json \
+              --formula-dir Formulas
+            ruby .github/scripts/render_report.rb \
+              --input-dir results \
+              --output-dir reports \
+              --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
+              --commit-sha "${{ github.sha }}" || true
+          else
+            echo "No JSONL results found"
+          fi
 
       - name: Check for changes
         id: changes
@@ -149,6 +177,14 @@ jobs:
             git diff --stat
           fi
 
+      - name: Read report summary
+        id: report
+        if: always() && hashFiles('reports/pr-comment.md') != ''
+        run: |
+          echo "body<<EOF" >> $GITHUB_OUTPUT
+          cat reports/pr-comment.md >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+
       - name: Create Pull Request
         if: steps.changes.outputs.has_changes == 'true'
         uses: peter-evans/create-pull-request@v6
@@ -156,6 +192,10 @@ jobs:
           branch: archive-sync-${{ github.run_number }}
           title: "chore: archive sync $(date +%Y-%m-%d)"
           body: |
+            ${{ steps.report.outputs.body }}
+
+            ---
+
             Automated archive.org mirror sync.
 
             - **Chunks processed**: ${{ needs.prepare.outputs.total }}

--- a/process/archive_fonts.rb
+++ b/process/archive_fonts.rb
@@ -4,6 +4,8 @@
 require "thor"
 require "yaml"
 require "time"
+require "json"
+require "fileutils"
 require_relative "archive_fonts/registry"
 require_relative "archive_fonts/registry_entry"
 require_relative "archive_fonts/url_collector"
@@ -49,7 +51,15 @@ class ArchiveFontsCLI < Thor
   desc "archive URL", "Archive a specific URL to the Wayback Machine"
   option :formula, type: :string, desc: "Formula file to update with mirror"
   option :registry, type: :string, default: "process/archive_registry.yml"
+  option :json_output, type: :string, desc: "Append result as JSONL to this file"
   def archive(url)
+    result = {
+      url: url,
+      formula: options[:formula],
+      started_at: Time.now.utc.iso8601,
+      status: nil,
+    }
+
     registry = ArchiveFonts::Registry.load(options[:registry])
     client = ArchiveFonts::ArchiveClient.new
     updater = ArchiveFonts::FormulaUpdater.new
@@ -59,32 +69,134 @@ class ArchiveFontsCLI < Thor
     archive_url = client.check_availability(url)
     if archive_url && client.validate_snapshot(archive_url)
       puts "Already archived: #{archive_url}"
+      result[:status] = "archived"
+      result[:archive_url] = archive_url
+      result[:note] = "already_archived"
     else
       archive_url = client.submit(url)
       if archive_url
         puts "Archived: #{archive_url}"
+        result[:status] = "archived"
+        result[:archive_url] = archive_url
+        result[:note] = "newly_archived"
       else
         puts "FAILED to archive"
-        return
+        result[:status] = "failed"
+        result[:error] = "archive.org submission returned no URL"
       end
     end
 
-    entry = ArchiveFonts::RegistryEntry.new(
-      url: url,
-      status: "archived",
-      archive_url: archive_url,
-      original_alive: true,
-      last_checked: Time.now.utc.iso8601,
-      formulas: options[:formula] ? [options[:formula]] : [],
-    )
-    registry.upsert(entry)
+    if result[:status] == "archived"
+      entry = ArchiveFonts::RegistryEntry.new(
+        url: url,
+        status: "archived",
+        archive_url: archive_url,
+        original_alive: true,
+        last_checked: Time.now.utc.iso8601,
+        formulas: options[:formula] ? [options[:formula]] : [],
+      )
+      registry.upsert(entry)
 
-    if options[:formula]
-      updater.add_mirror(options[:formula], url, archive_url, dry_run: options[:dry_run])
+      if options[:formula]
+        updater.add_mirror(options[:formula], url, archive_url, dry_run: options[:dry_run])
+      end
+
+      registry.save
+      puts "Registry saved."
     end
 
-    registry.save
-    puts "Registry saved."
+    result[:completed_at] = Time.now.utc.iso8601
+    append_jsonl(result)
+  end
+
+  desc "report", "Aggregate JSONL chunk results into render_report-compatible JSON"
+  option :input_dir, type: :string, default: "results", desc: "Dir with chunk-*.jsonl files"
+  option :output, type: :string, default: "results/archive.json", desc: "Output JSON path"
+  option :formula_dir, type: :string, default: "Formulas"
+  def report
+    files = Dir.glob(File.join(options[:input_dir], "**/*.jsonl")).sort
+    records = []
+    files.each do |f|
+      File.foreach(f) { |line| records << JSON.parse(line) if line.strip! && !line.empty? }
+    rescue StandardError => e
+      warn "WARN: Failed to parse #{f}: #{e.message}"
+    end
+
+    url_to_formulas = build_url_to_formula_map
+
+    failures = records.select { |r| r["status"] != "archived" }.map do |r|
+      formula_paths = url_to_formulas[r["url"]] || []
+      {
+        "formula" => formula_paths.first || File.basename(r["url"]),
+        "formula_path" => formula_paths.first,
+        "url" => r["url"],
+        "message" => r["error"] || r["status"],
+        "severity" => "error",
+      }
+    end
+
+    warnings = records.select { |r| r["note"] == "already_archived" }.map do |r|
+      formula_paths = url_to_formulas[r["url"]] || []
+      {
+        "formula" => formula_paths.first || File.basename(r["url"]),
+        "formula_path" => formula_paths.first,
+        "url" => r["url"],
+        "message" => "Already archived (skipped submission)",
+        "severity" => "warning",
+      }
+    end
+
+    summary = {
+      "total" => records.size,
+      "passed" => records.count { |r| r["status"] == "archived" && r["note"] != "already_archived" },
+      "failed" => records.count { |r| r["status"] != "archived" },
+      "warnings" => warnings.size,
+      "skipped" => records.count { |r| r["note"] == "already_archived" },
+    }
+
+    timestamps = records.map { |r| r["started_at"] }.compact.sort
+    data = {
+      "check" => "archive",
+      "platform" => "all",
+      "scope" => "full",
+      "started_at" => timestamps.first,
+      "completed_at" => Time.now.utc.iso8601,
+      "summary" => summary,
+      "failures" => failures,
+      "warnings" => warnings,
+    }
+
+    FileUtils.mkdir_p(File.dirname(options[:output]))
+    File.write(options[:output], JSON.pretty_generate(data))
+    puts "Report: #{records.size} URLs processed, #{summary["failed"]} failed"
+    puts "Output: #{options[:output]}"
+  end
+
+  private
+
+  def append_jsonl(result)
+    return unless options[:json_output]
+
+    FileUtils.mkdir_p(File.dirname(options[:json_output]))
+    File.open(options[:json_output], "a") { |f| f.puts(JSON.generate(result)) }
+  end
+
+  def build_url_to_formula_map
+    map = {}
+    Dir.glob(File.join(options[:formula_dir] || "Formulas", "**/*.yml")).each do |path|
+      content = YAML.load_file(path) rescue next
+      next unless content.is_a?(Hash) && content["resources"]
+
+      content["resources"].each_value do |res|
+        next unless res.is_a?(Hash) && res["urls"]
+
+        res["urls"].each do |url|
+          map[url] ||= []
+          map[url] << path unless map[url].include?(path)
+        end
+      end
+    end
+    map
   end
 
   desc "check", "Check archival status of URLs"


### PR DESCRIPTION
## Problem

The `archive-sync` workflow runs weekly (Wed 2am UTC) and creates automated PRs when it adds archive.org mirrors to formulas. The PR body previously said only:

> Automated archive.org mirror sync.
> - **Chunks processed**: N
> - Registry: `process/archive_registry.yml`
> - Formula updates: archive mirrors added/replaced

No detail about WHICH URLs succeeded or failed. Same failure mode as issue #225 had with formula-health.

## Solution

Applies the same 3-layer pattern from PR #270 (formula-health reports):

```
Layer 1 — CHECKER (archive_fonts.rb)
  archive subcommand gains --json-output (appends JSONL records per URL)
  Each record: { url, formula, started_at, status, archive_url, error, completed_at }

Layer 2 — AGGREGATOR (new: archive_fonts.rb report subcommand)
  Reads all chunk-*.jsonl files
  Maps URLs back to formula paths
  Produces results/archive.json in render_report-compatible schema

Layer 3 — PUBLISHER (archive-sync.yml collect job)
  Runs render_report.rb on results/
  Embeds reports/pr-comment.md in the PR body via create-pull-request
```

## Before / After

**Before** — PR body:
```
Automated archive.org mirror sync.
- Chunks processed: 12
- Registry: process/archive_registry.yml
- Formula updates: archive mirrors added/replaced
```

**After** — PR body includes the formatted report:
```
## ❯ Fontist formula checks: FAIL

| Check | Scope | Result |
|-------|-------|--------|
| archive | full · 150 items | ❌ 3 failed |

URLs — 3 failures
| Formula | Detail |
|---------|--------|
| `font_X` | https://...broken-url... · archive.org timeout |
| `font_Y` | https://...other-url... · submission returned no URL |
...

---

Automated archive.org mirror sync.
- Chunks processed: 12
...
```

## Files

**Modified:**
- `process/archive_fonts.rb` — `archive` subcommand gains `--json-output`; new `report` subcommand aggregates JSONL
- `.github/workflows/archive-sync.yml` — each chunk writes JSONL, collect job runs `report` + `render_report.rb`, PR body includes formatted output

## Test coverage

Smoke-tested locally with 3-record JSONL fixture:
- 1 newly archived URL → counted as passed
- 1 already-archived URL → counted as warning (skipped submission)
- 1 failed URL → counted as failure, rendered in failure section

Output verified: `render_report.rb` consumes the JSON and produces correct pr-comment.md with summary table + failure details.

## Depends on

PR #270 (merged) — `render_report.rb` in `.github/scripts/` and the unified JSON schema.
