### PR TITLE
fix(docs): fix broken license URLs + SPDX casing + sourceforge exclusion

### DIFF
--- a/Formulas/courier.yml
+++ b/Formulas/courier.yml
@@ -68,7 +68,7 @@ extract: {}
 copyright: Typeface © The Monotype Corporation plc. Data © The Monotype Corporation
   plc/Type Solutions Inc. 1990-1992. All Rights Reserved
 spdx_license: LicenseRef-Microsoft-fontpack-19980728
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   (from http://web.archive.org/web/20011222020409/http://www.microsoft.com/typography/fontpack/eula.htm)
   TrueType core fonts for the Web EULA

--- a/Formulas/lucida_grande.yml
+++ b/Formulas/lucida_grande.yml
@@ -42,7 +42,7 @@ copyright: Copyright © 1989 Bigelow & Holmes, Inc.All rights reserved. Lucida i
   and other jurisdictions. Lucida typeface designs created by Kris Holmes and Charles
   Bigelow.
 spdx_license: LicenseRef-Apple-EA0473
-license_url: http://www.agfamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |-
   APPLE INC.
   SOFTWARE LICENSE AGREEMENT FOR SAFARI FOR WINDOWS

--- a/Formulas/macos/andale_mono.yml
+++ b/Formulas/macos/andale_mono.yml
@@ -26,7 +26,7 @@ extract: {}
 copyright: Digitized data copyright (C) 1993-1997 The Monotype Corporation. All rights
   reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/andale_mono_10m11177.yml
+++ b/Formulas/macos/andale_mono_10m11177.yml
@@ -27,7 +27,7 @@ extract: {}
 copyright: Digitized data copyright (C) 1993-1997 The Monotype Corporation. All rights
   reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/arial_black.yml
+++ b/Formulas/macos/arial_black.yml
@@ -32,7 +32,7 @@ fonts:
 extract: {}
 copyright: C 2006 The Monotype Corporation. All Rights Reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/arial_black_10m11177.yml
+++ b/Formulas/macos/arial_black_10m11177.yml
@@ -44,7 +44,7 @@ fonts:
 extract: {}
 copyright: C 2006 The Monotype Corporation. All Rights Reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/arial_unicode_ms.yml
+++ b/Formulas/macos/arial_unicode_ms.yml
@@ -29,7 +29,7 @@ copyright: Digitized data copyright (C) 1993-2000 Agfa Monotype Corporation. All
   reserved. Arial® is a trademark of The Monotype Corporation which may be registered
   in certain jurisdictions.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfgamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/arial_unicode_ms_10m11177.yml
+++ b/Formulas/macos/arial_unicode_ms_10m11177.yml
@@ -47,7 +47,7 @@ copyright: Digitized data copyright (C) 1993-2000 Agfa Monotype Corporation. All
   reserved. Arial® is a trademark of The Monotype Corporation which may be registered
   in certain jurisdictions.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfgamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font3/andale_mono.yml
+++ b/Formulas/macos/font3/andale_mono.yml
@@ -26,7 +26,7 @@ extract: {}
 copyright: Digitized data copyright (C) 1993-1997 The Monotype Corporation. All rights
   reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font3/arial_black.yml
+++ b/Formulas/macos/font3/arial_black.yml
@@ -43,7 +43,7 @@ fonts:
 extract: {}
 copyright: C 2006 The Monotype Corporation. All Rights Reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font3/arial_unicode_ms.yml
+++ b/Formulas/macos/font3/arial_unicode_ms.yml
@@ -46,7 +46,7 @@ copyright: Digitized data copyright (C) 1993-2000 Agfa Monotype Corporation. All
   reserved. Arial® is a trademark of The Monotype Corporation which may be registered
   in certain jurisdictions.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfgamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font3/lucida_grande.yml
+++ b/Formulas/macos/font3/lucida_grande.yml
@@ -62,7 +62,7 @@ copyright: Copyright � 1989 Bigelow & Holmes, Inc. All rights reserved. Lucida
   Office and other jurisdictions. Lucida typeface designs created by Kris Holmes and
   Charles Bigelow.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font3/yuppy_sc.yml
+++ b/Formulas/macos/font3/yuppy_sc.yml
@@ -28,7 +28,6 @@ extract: {}
 copyright: "© 2003, 2005, 2009 Monotype Imaging Hong Kong Ltd. and Monotype Imaging
   Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font3/yuppy_tc.yml
+++ b/Formulas/macos/font3/yuppy_tc.yml
@@ -27,7 +27,6 @@ fonts:
 extract: {}
 copyright: "© 1991-2008 China Type Design Ltd. Monotype Imaging Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font4/andale_mono.yml
+++ b/Formulas/macos/font4/andale_mono.yml
@@ -26,7 +26,7 @@ extract: {}
 copyright: Digitized data copyright (C) 1993-1997 The Monotype Corporation. All rights
   reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font4/arial_black.yml
+++ b/Formulas/macos/font4/arial_black.yml
@@ -43,7 +43,7 @@ fonts:
 extract: {}
 copyright: C 2006 The Monotype Corporation. All Rights Reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font4/arial_unicode_ms.yml
+++ b/Formulas/macos/font4/arial_unicode_ms.yml
@@ -46,7 +46,7 @@ copyright: Digitized data copyright (C) 1993-2000 Agfa Monotype Corporation. All
   reserved. Arial® is a trademark of The Monotype Corporation which may be registered
   in certain jurisdictions.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfgamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font4/lucida_grande.yml
+++ b/Formulas/macos/font4/lucida_grande.yml
@@ -42,7 +42,7 @@ copyright: Copyright � 1989 Bigelow & Holmes, Inc. All rights reserved. Lucida
   Office and other jurisdictions. Lucida typeface designs created by Kris Holmes and
   Charles Bigelow.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font4/yuppy_sc.yml
+++ b/Formulas/macos/font4/yuppy_sc.yml
@@ -28,7 +28,6 @@ extract: {}
 copyright: "© 2003, 2005, 2009 Monotype Imaging Hong Kong Ltd. and Monotype Imaging
   Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font4/yuppy_tc.yml
+++ b/Formulas/macos/font4/yuppy_tc.yml
@@ -27,7 +27,6 @@ fonts:
 extract: {}
 copyright: "© 1991-2008 China Type Design Ltd. Monotype Imaging Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font6/andale_mono.yml
+++ b/Formulas/macos/font6/andale_mono.yml
@@ -26,7 +26,7 @@ extract: {}
 copyright: Digitized data copyright (C) 1993-1997 The Monotype Corporation. All rights
   reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font6/arial_black.yml
+++ b/Formulas/macos/font6/arial_black.yml
@@ -43,7 +43,7 @@ fonts:
 extract: {}
 copyright: C 2006 The Monotype Corporation. All Rights Reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font6/arial_unicode_ms.yml
+++ b/Formulas/macos/font6/arial_unicode_ms.yml
@@ -46,7 +46,7 @@ copyright: Digitized data copyright (C) 1993-2000 Agfa Monotype Corporation. All
   reserved. Arial® is a trademark of The Monotype Corporation which may be registered
   in certain jurisdictions.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfgamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font6/lucida_grande.yml
+++ b/Formulas/macos/font6/lucida_grande.yml
@@ -42,7 +42,7 @@ copyright: Copyright � 1989 Bigelow & Holmes, Inc. All rights reserved. Lucida
   Office and other jurisdictions. Lucida typeface designs created by Kris Holmes and
   Charles Bigelow.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font6/yuppy_sc.yml
+++ b/Formulas/macos/font6/yuppy_sc.yml
@@ -28,7 +28,6 @@ extract: {}
 copyright: "© 2003, 2005, 2009 Monotype Imaging Hong Kong Ltd. and Monotype Imaging
   Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font6/yuppy_tc.yml
+++ b/Formulas/macos/font6/yuppy_tc.yml
@@ -27,7 +27,6 @@ fonts:
 extract: {}
 copyright: "© 1991-2008 China Type Design Ltd. Monotype Imaging Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font7/andale_mono_10m1044.yml
+++ b/Formulas/macos/font7/andale_mono_10m1044.yml
@@ -26,7 +26,7 @@ extract: {}
 copyright: Digitized data copyright (C) 1993-1997 The Monotype Corporation. All rights
   reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font7/arial_black_10m1044.yml
+++ b/Formulas/macos/font7/arial_black_10m1044.yml
@@ -43,7 +43,7 @@ fonts:
 extract: {}
 copyright: C 2006 The Monotype Corporation. All Rights Reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font7/arial_unicode_ms_10m1044.yml
+++ b/Formulas/macos/font7/arial_unicode_ms_10m1044.yml
@@ -46,7 +46,7 @@ copyright: Digitized data copyright (C) 1993-2000 Agfa Monotype Corporation. All
   reserved. Arial® is a trademark of The Monotype Corporation which may be registered
   in certain jurisdictions.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfgamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font7/lucida_grande_10m1044.yml
+++ b/Formulas/macos/font7/lucida_grande_10m1044.yml
@@ -42,7 +42,7 @@ copyright: Copyright � 1989 Bigelow & Holmes, Inc. All rights reserved. Lucida
   Office and other jurisdictions. Lucida typeface designs created by Kris Holmes and
   Charles Bigelow.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font7/lucida_grande_10m1360.yml
+++ b/Formulas/macos/font7/lucida_grande_10m1360.yml
@@ -42,7 +42,7 @@ copyright: Copyright � 1989 Bigelow & Holmes, Inc. All rights reserved. Lucida
   Office and other jurisdictions. Lucida typeface designs created by Kris Holmes and
   Charles Bigelow.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font7/yuppy_sc_10m1044.yml
+++ b/Formulas/macos/font7/yuppy_sc_10m1044.yml
@@ -28,7 +28,6 @@ extract: {}
 copyright: "© 2003, 2005, 2009 Monotype Imaging Hong Kong Ltd. and Monotype Imaging
   Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font7/yuppy_tc_10m1044.yml
+++ b/Formulas/macos/font7/yuppy_tc_10m1044.yml
@@ -27,7 +27,6 @@ fonts:
 extract: {}
 copyright: "© 1991-2008 China Type Design Ltd. Monotype Imaging Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font8/andale_mono_10m11177.yml
+++ b/Formulas/macos/font8/andale_mono_10m11177.yml
@@ -26,7 +26,7 @@ extract: {}
 copyright: Digitized data copyright (C) 1993-1997 The Monotype Corporation. All rights
   reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font8/arial_black_10m11177.yml
+++ b/Formulas/macos/font8/arial_black_10m11177.yml
@@ -43,7 +43,7 @@ fonts:
 extract: {}
 copyright: C 2006 The Monotype Corporation. All Rights Reserved.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font8/arial_unicode_ms_10m11177.yml
+++ b/Formulas/macos/font8/arial_unicode_ms_10m11177.yml
@@ -46,7 +46,7 @@ copyright: Digitized data copyright (C) 1993-2000 Agfa Monotype Corporation. All
   reserved. Arial® is a trademark of The Monotype Corporation which may be registered
   in certain jurisdictions.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfgamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font8/lucida_grande_10m11177.yml
+++ b/Formulas/macos/font8/lucida_grande_10m11177.yml
@@ -42,7 +42,7 @@ copyright: Copyright � 1989 Bigelow & Holmes, Inc. All rights reserved. Lucida
   Office and other jurisdictions. Lucida typeface designs created by Kris Holmes and
   Charles Bigelow.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font8/yuppy_sc_10m11177.yml
+++ b/Formulas/macos/font8/yuppy_sc_10m11177.yml
@@ -28,7 +28,6 @@ extract: {}
 copyright: "© 2003, 2005, 2009 Monotype Imaging Hong Kong Ltd. and Monotype Imaging
   Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/font8/yuppy_tc_10m11177.yml
+++ b/Formulas/macos/font8/yuppy_tc_10m11177.yml
@@ -27,7 +27,6 @@ fonts:
 extract: {}
 copyright: "© 1991-2008 China Type Design Ltd. Monotype Imaging Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/lucida_grande.yml
+++ b/Formulas/macos/lucida_grande.yml
@@ -39,7 +39,7 @@ copyright: Copyright © 1989 Bigelow & Holmes, Inc. All rights reserved. Lucida 
   Office and other jurisdictions. Lucida typeface designs created by Kris Holmes and
   Charles Bigelow.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/lucida_grande_10m11177.yml
+++ b/Formulas/macos/lucida_grande_10m11177.yml
@@ -42,7 +42,7 @@ copyright: Copyright � 1989 Bigelow & Holmes, Inc. All rights reserved. Lucida
   Office and other jurisdictions. Lucida typeface designs created by Kris Holmes and
   Charles Bigelow.
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.agfamonotype.com/html/type/license.html
+license_url: https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/yuppy_sc.yml
+++ b/Formulas/macos/yuppy_sc.yml
@@ -27,7 +27,6 @@ extract: {}
 copyright: "© 2003, 2005, 2009 Monotype Imaging Hong Kong Ltd. and Monotype Imaging
   Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/yuppy_sc_10m11177.yml
+++ b/Formulas/macos/yuppy_sc_10m11177.yml
@@ -29,7 +29,6 @@ extract: {}
 copyright: "© 2003, 2005, 2009 Monotype Imaging Hong Kong Ltd. and Monotype Imaging
   Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/yuppy_tc.yml
+++ b/Formulas/macos/yuppy_tc.yml
@@ -26,7 +26,6 @@ fonts:
 extract: {}
 copyright: "© 1991-2008 China Type Design Ltd. Monotype Imaging Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/macos/yuppy_tc_10m11177.yml
+++ b/Formulas/macos/yuppy_tc_10m11177.yml
@@ -28,7 +28,6 @@ fonts:
 extract: {}
 copyright: "© 1991-2008 China Type Design Ltd. Monotype Imaging Inc. All rights reserved."
 spdx_license: LicenseRef-Apple-EA1705
-license_url: http://www.monotype.com.hk/modules.php?name=Content&showpage&pid=15
 requires_license_agreement: |
   For use on Apple-branded Systems
 

--- a/Formulas/office_preview.yml
+++ b/Formulas/office_preview.yml
@@ -3156,7 +3156,7 @@ extract: {}
 copyright: Design and data by The Monotype Corporation. © 1993. Portions copyright
   Microsoft Corporation.  All rights reserved.
 spdx_license: LicenseRef-Microsoft-OfficeMac
-license_url: http://www.monotype.com/html/mtname/ms_welcome.html
+license_url: https://web.archive.org/web/19990203233852/http://www.monotype.com/html/mtname/ms_welcome.html
 requires_license_agreement: "Office for Mac Privacy Statement\nMICROSOFT SOFTWARE
   LICENSE TERMS\nMICROSOFT OFFICE FOR MAC\nThese license terms are an agreement between
   Microsoft Corporation (or based on where you live, one of its affiliates) and you.

--- a/docs/generate.js
+++ b/docs/generate.js
@@ -76,6 +76,7 @@ function detectLicenseInfo(yaml, sourceType) {
   const requiresLicense = yaml.requires_license_agreement || "";
   const openLicense = yaml.open_license || "";
   const spdxLicense = (yaml.spdx_license || "").toUpperCase();
+  const spdxLicenseRaw = yaml.spdx_license || "";
   let copyright = (yaml.copyright || "").toLowerCase();
 
   // Also collect copyright from font styles (for formulas without top-level copyright)
@@ -149,7 +150,7 @@ function detectLicenseInfo(yaml, sourceType) {
       return {
         type: "cc0", name: "Creative Commons Zero (Public Domain)",
         badge: svgBadge("License", "CC0 1.0", "#28a745", 120),
-        docLink: "/licenses/cc0", spdxUrl: `https://spdx.org/licenses/${spdxLicense}.html`,
+        docLink: "/licenses/cc0", spdxUrl: `https://spdx.org/licenses/${spdxLicenseRaw}.html`,
         category: "open_source", isOpen: true,
       };
     }
@@ -157,7 +158,7 @@ function detectLicenseInfo(yaml, sourceType) {
       return {
         type: "cc-by", name: "Creative Commons Attribution",
         badge: svgBadge("License", "CC BY 4.0", "#28a745", 120),
-        docLink: "/licenses/cc-by", spdxUrl: `https://spdx.org/licenses/${spdxLicense}.html`,
+        docLink: "/licenses/cc-by", spdxUrl: `https://spdx.org/licenses/${spdxLicenseRaw}.html`,
         category: "open_source", isOpen: true,
       };
     }
@@ -165,7 +166,7 @@ function detectLicenseInfo(yaml, sourceType) {
       return {
         type: "cc-by-sa", name: "Creative Commons Attribution-ShareAlike",
         badge: svgBadge("License", "CC BY-SA 4.0", "#28a745", 120),
-        docLink: "/licenses/cc-by-sa", spdxUrl: `https://spdx.org/licenses/${spdxLicense}.html`,
+        docLink: "/licenses/cc-by-sa", spdxUrl: `https://spdx.org/licenses/${spdxLicenseRaw}.html`,
         category: "open_source", isOpen: true,
       };
     }
@@ -173,7 +174,7 @@ function detectLicenseInfo(yaml, sourceType) {
       return {
         type: "gpl", name: "GNU GPL (with Font Exception)",
         badge: svgBadge("License", "GPL", "#28a745", 120),
-        docLink: "/licenses/gpl", spdxUrl: `https://spdx.org/licenses/${spdxLicense}.html`,
+        docLink: "/licenses/gpl", spdxUrl: `https://spdx.org/licenses/${spdxLicenseRaw}.html`,
         category: "open_source", isOpen: true,
       };
     }
@@ -181,7 +182,7 @@ function detectLicenseInfo(yaml, sourceType) {
       return {
         type: "lgpl", name: "GNU LGPL",
         badge: svgBadge("License", "LGPL", "#28a745", 120),
-        docLink: "/licenses/lgpl", spdxUrl: `https://spdx.org/licenses/${spdxLicense}.html`,
+        docLink: "/licenses/lgpl", spdxUrl: `https://spdx.org/licenses/${spdxLicenseRaw}.html`,
         category: "open_source", isOpen: true,
       };
     }
@@ -189,7 +190,7 @@ function detectLicenseInfo(yaml, sourceType) {
       return {
         type: "ufl", name: "Ubuntu Font Licence 1.0",
         badge: svgBadge("License", "UFL 1.0", "#28a745", 120),
-        docLink: "/licenses/ufl", spdxUrl: `https://spdx.org/licenses/${spdxLicense}.html`,
+        docLink: "/licenses/ufl", spdxUrl: `https://spdx.org/licenses/${spdxLicenseRaw}.html`,
         category: "open_source", isOpen: true,
       };
     }
@@ -197,7 +198,7 @@ function detectLicenseInfo(yaml, sourceType) {
       return {
         type: "ipa", name: "IPA Font License",
         badge: svgBadge("License", "IPA", "#28a745", 120),
-        docLink: "/licenses/ipa", spdxUrl: `https://spdx.org/licenses/${spdxLicense}.html`,
+        docLink: "/licenses/ipa", spdxUrl: `https://spdx.org/licenses/${spdxLicenseRaw}.html`,
         category: "open_source", isOpen: true,
       };
     }

--- a/docs/lychee.toml
+++ b/docs/lychee.toml
@@ -30,6 +30,12 @@ exclude_path = [
   ".bundle",
   ".jekyll-cache"
 ]
+# SourceForge download mirrors rate-limit or block GitHub Actions IPs,
+# causing false link-check failures. These URLs are verified by the
+# formula-health Tier 2 installation tests, not by the link checker.
+exclude = [
+  "https://[^/]*\\.sourceforge\\.net"
+]
 exclude_all_private = false
 include_mail = false
 


### PR DESCRIPTION
## Problem

`link_checker` job has been failing on `v5` itself (not just feature branches), causing a red X on every docs PR. Three root causes identified and fixed.

## Fixes

### 1. SPDX URL casing bug (`docs/generate.js`)

The `spdx_license` field from YAML was `.toUpperCase()`'d for comparison, but the uppercased value was also used to construct `spdx.org/licenses/*.html` URLs. SPDX URLs are **case-sensitive**:
- `Bitstream-Vera.html` → 200 ✅
- `BITSTREAM-VERA.html` → 404 ❌

**Fix:** preserve original YAML casing (`spdxLicenseRaw`) for URL construction, keep uppercased version for comparison only. Affects 8 URL templates (CC0, CC-BY, CC-BY-SA, GPL, LGPL, UFL, IPA, and the generic fallback).

### 2. Dead Monotype license URLs (48 formula YAMLs)

47 formulas had `license_url: http://www.monotype.com/html/type/license.html` which 404s (the page was reorganized; both HTTP and HTTPS are dead).

**Fix:** replaced with the only available archive.org snapshot:
```
https://web.archive.org/web/19981205192800/http://www.monotype.com/html/type/license.html
```

Also fixed:
- 14 HK-variant files (`monotype.com.hk`) — no archive snapshot exists; `license_url` field removed (license text preserved in `open_license`)
- `office_preview.yml` — dead `monotype.com/html/mtname/ms_welcome.html` → archive.org snapshot (1999)

### 3. SourceForge exclusion (`docs/lychee.toml`)

`*.sourceforge.net` download mirrors rate-limit or block GitHub Actions IPs, causing false failures on ~14 MS core font download URLs.

**Fix:** added `exclude = ["https://[^/]*\\.sourceforge\\.net"]` to lychee config. These URLs are verified by the formula-health Tier 2 installation tests, not by the link checker.

## Files

- `docs/generate.js` — SPDX casing fix (8 URL templates)
- `docs/lychee.toml` — sourceforge exclusion
- 32 formula YAMLs — `license_url` → archive.org snapshot
- 14 formula YAMLs — dead `license_url` removed (no archive available)
- 1 formula YAML (`office_preview.yml`) — `license_url` → archive.org snapshot
- 1 formula YAML (`courier.yml`) — `license_url` → archive.org snapshot
