### PR TITLE
fix: replace dead sourceforge mirror + fix eurofix archive URL (#246)

### DIFF
--- a/Formulas/andale.yml
+++ b/Formulas/andale.yml
@@ -8,7 +8,7 @@ resources:
     urls:
     - https://gitlab.com/fontmirror/archive/-/raw/master/andale32.exe
     - https://web.archive.org/web/20260506003127/https://gitlab.com/fontmirror/archive/-/raw/master/andale32.exe
-    - https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/andale32.exe
+    - https://downloads.sourceforge.net/project/corefonts/the%20fonts/final/andale32.exe
     - http://sft.if.usp.br/msttcorefonts/andale32.exe
     - https://web.archive.org/web/20260506003253/http://sft.if.usp.br/msttcorefonts/andale32.exe
     sha256: 0524fe42951adc3a7eb870e32f0920313c71f170c859b5f770d82b4ee111e970

--- a/Formulas/arial_black.yml
+++ b/Formulas/arial_black.yml
@@ -7,8 +7,8 @@ resources:
     urls:
     - https://gitlab.com/fontmirror/archive/-/raw/master/arialb32.exe
     - https://web.archive.org/web/20260506003306/https://gitlab.com/fontmirror/archive/-/raw/master/arialb32.exe
-    - https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/arialb32.exe
-    - http://web.archive.org/web/20160410121511/http://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/arialb32.exe
+    - https://downloads.sourceforge.net/project/corefonts/the%20fonts/final/arialb32.exe
+    - http://web.archive.org/web/20160410121511/http://downloads.sourceforge.net/project/corefonts/the%20fonts/final/arialb32.exe
     - http://sft.if.usp.br/msttcorefonts/arialb32.exe
     - https://web.archive.org/web/20260506003339/http://sft.if.usp.br/msttcorefonts/arialb32.exe
     sha256: a425f0ffb6a1a5ede5b979ed6177f4f4f4fdef6ae7c302a7b7720ef332fec0a8

--- a/Formulas/cleartype.yml
+++ b/Formulas/cleartype.yml
@@ -8,7 +8,7 @@ resources:
   PowerPointViewer.exe:
     urls:
     - https://gitlab.com/fontmirror/archive/-/raw/master/PowerPointViewer.exe
-    - https://nchc.dl.sourceforge.net/project/mscorefonts2/cabs/PowerPointViewer.exe
+    - https://downloads.sourceforge.net/project/mscorefonts2/cabs/PowerPointViewer.exe
     - https://sourceforge.net/projects/mscorefonts2/files/cabs/PowerPointViewer.exe/download
     - https://web.archive.org/web/20171225132744if_/http://download.microsoft.com/download/E/6/7/E675FFFC-2A6D-4AB0-B3EB-27C9F8C8F696/PowerPointViewer.exe
     - https://archive.org/download/PowerPointViewer_201801/PowerPointViewer.exe

--- a/Formulas/comic.yml
+++ b/Formulas/comic.yml
@@ -8,7 +8,7 @@ resources:
     urls:
     - https://gitlab.com/fontmirror/archive/-/raw/master/comic32.exe
     - https://web.archive.org/web/20260506003829/https://gitlab.com/fontmirror/archive/-/raw/master/comic32.exe
-    - https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/comic32.exe
+    - https://downloads.sourceforge.net/project/corefonts/the%20fonts/final/comic32.exe
     - http://sft.if.usp.br/msttcorefonts/comic32.exe
     - https://web.archive.org/web/20260506003920/http://sft.if.usp.br/msttcorefonts/comic32.exe
     sha256: 9c6df3feefde26d4e41d4a4fe5db2a89f9123a772594d7f59afd062625cd204e

--- a/Formulas/courier.yml
+++ b/Formulas/courier.yml
@@ -8,7 +8,7 @@ resources:
     urls:
     - https://gitlab.com/fontmirror/archive/-/raw/master/courie32.exe
     - https://web.archive.org/web/20260506003942/https://gitlab.com/fontmirror/archive/-/raw/master/courie32.exe
-    - https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/courie32.exe
+    - https://downloads.sourceforge.net/project/corefonts/the%20fonts/final/courie32.exe
     - http://sft.if.usp.br/msttcorefonts/courie32.exe
     - https://web.archive.org/web/20260505172832/http://sft.if.usp.br/msttcorefonts/courie32.exe
     sha256: bb511d861655dde879ae552eb86b134d6fae67cb58502e6ff73ec5d9151f3384

--- a/Formulas/eurofix.yml
+++ b/Formulas/eurofix.yml
@@ -5,7 +5,7 @@ homepage: https://docs.microsoft.com/en-us/previous-versions//cc767898(v=technet
 resources:
   EuroFix.exe:
     urls:
-    - http://web.archive.org/web/20030118044911/http://download.microsoft.com:80/msdownload/euro/wts/x86/eurofixi.exe
+    - https://web.archive.org/web/20000820212157/http://download.microsoft.com/msdownload/euro/wts/x86/eurofixi.exe
     sha256: 41f272a33521f6e15f2cce9ff1e049f2badd5ff0dc327fc81b60825766d5b6c7
     file_size: 1930192
 fonts:
@@ -251,4 +251,4 @@ requires_license_agreement: |-
   POSSIBILITY OF SUCH DAMAGES.  SOME STATES DO NOT ALLOW THE EXCLUSION
   OR LIMITATION OF LIABILITY FOR CONSEQUENTIAL OR INCIDENTAL DAMAGES
   SO THE FOREGOING LIMITATION MAY NOT APPLY.
-command: create-formula --name EuroFix http://web.archive.org/web/20030118044911/http://download.microsoft.com:80/msdownload/euro/wts/x86/eurofixi.exe
+command: create-formula --name EuroFix https://web.archive.org/web/20000820212157/http://download.microsoft.com/msdownload/euro/wts/x86/eurofixi.exe

--- a/Formulas/georgia.yml
+++ b/Formulas/georgia.yml
@@ -7,7 +7,7 @@ resources:
   georgi32.exe:
     urls:
     - https://gitlab.com/fontmirror/archive/-/raw/master/georgi32.exe
-    - https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/georgi32.exe
+    - https://downloads.sourceforge.net/project/corefonts/the%20fonts/final/georgi32.exe
     - http://sft.if.usp.br/msttcorefonts/georgi32.exe
     sha256: 2c2c7dcda6606ea5cf08918fb7cd3f3359e9e84338dc690013f20cd42e930301
     file_size: 392440

--- a/Formulas/impact.yml
+++ b/Formulas/impact.yml
@@ -7,7 +7,7 @@ resources:
   impact32.exe:
     urls:
     - https://gitlab.com/fontmirror/archive/-/raw/master/impact32.exe
-    - https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/impact32.exe
+    - https://downloads.sourceforge.net/project/corefonts/the%20fonts/final/impact32.exe
     - http://sft.if.usp.br/msttcorefonts/impact32.exe
     sha256: 6061ef3b7401d9642f5dfdb5f2b376aa14663f6275e60a51207ad4facf2fccfb
     file_size: 173288

--- a/Formulas/webding.yml
+++ b/Formulas/webding.yml
@@ -7,7 +7,7 @@ resources:
   webdin32.exe:
     urls:
     - https://gitlab.com/fontmirror/archive/-/raw/master/webdin32.exe
-    - https://nchc.dl.sourceforge.net/project/corefonts/the%20fonts/final/webdin32.exe
+    - https://downloads.sourceforge.net/project/corefonts/the%20fonts/final/webdin32.exe
     - http://sft.if.usp.br/msttcorefonts/webdin32.exe
     sha256: 64595b5abc1080fba8610c5c34fab5863408e806aafe84653ca8575bed17d75a
     file_size: 185072


### PR DESCRIPTION
## Problem

Issue #246: MS font URLs that no longer work. Local URL scan (using the now-fixed `check_urls.rb` from PR #270) found 9 dead URLs across 8 formulas.

## Root causes

1. **Dead SourceForge mirror** (8 formulas): `nchc.dl.sourceforge.net` (Taiwan mirror) has been consistently unreachable. Affects MS Core Fonts for the Web (andale, arial_black, comic, courier, georgia, impact, webding) + PowerPointViewer (cleartype).

2. **Dead archive.org snapshot** (1 formula): `eurofix.yml` had a snapshot from timestamp `20030118044911` that returns 404.

## Fixes

- **SourceForge**: `nchc.dl.sourceforge.net` → `downloads.sourceforge.net` (auto-redirects to a working mirror via 302)
- **Eurofix**: dead snapshot → working snapshot from `20000820212157` (verified via CDX API, HTTP 200, `application/x-msdownload`)

## Verification

Re-ran `check_urls.rb` on all 9 affected formulas after fix:

```
URLs checked:    36
Errors:          0
Warnings:        0

All URLs are accessible.
```

## Scope

This is the first batch of #246. The formula-health workflow (PR #270) will automatically surface any remaining dead URLs in the next scheduled run. Each batch of dead URLs will be fixed in follow-up PRs.

## Files

9 formula YAMLs modified (11 lines changed total).