### PR TITLE
security: redact query strings from URLs in reports

### DIFF
--- a/.github/scripts/render_report.rb
+++ b/.github/scripts/render_report.rb
@@ -297,12 +297,18 @@ class RenderReport
     parts = []
     if failure["url"]
       url = failure["url"]
-      # Truncate long URLs for readability in tables
-      display = url.size > 80 ? "#{url[0..77]}..." : url
-      parts << "[`#{display}`](#{url})"
+      safe_url = redact_url(url)
+      parts << "[`#{safe_url}`](#{safe_url})"
     end
     parts << failure["message"].to_s if failure["message"]
     parts.join(" · ")
+  end
+
+  def redact_url(url)
+    return url unless url.is_a?(String) && url.include?("?")
+
+    base = url.split("?").first
+    "#{base}?…(query redacted)"
   end
 
   def pr_footer


### PR DESCRIPTION
## Security fix — URGENT

GitHub secret scanning detected an AWS Temporary Access Key ID (`ASIA6KOSE3BNEPKIWAEW`) in a PR comment on #276. The formula-checks job (from PR #270) posted a sticky comment that included a formula URL with credentials in its query string.

## What happened
1. A formula URL with pre-signed S3 credentials was checked by `check_urls.rb`
2. The URL (including credentials in query params) was stored in the failure record
3. `render_report.rb` printed the raw URL verbatim in the PR comment
4. GitHub secret scanning detected the AWS key pattern

## Actions taken
- Comment deleted (comment ID 4756940285)
- Secret scanning alert #2 resolved (key was temporary STS credential with auto-expiry)
- `redact_url()` method added to `render_report.rb` — strips query strings from all URLs in output

## Fix
New method `redact_url(url)` strips everything after `?` and replaces with `(query redacted)`. Applied to `format_failure_detail()` — renders URLs in failure tables (PR comments, issue bodies, step summaries). Normal URLs without query strings are unaffected.

## Verification
- URL with credentials: `https://example.com/file.exe?X-Amz-Credential=ASIA...` → redacted to `https://example.com/file.exe?…(query redacted)`
- Normal URL: `https://example.com/file.zip` → unchanged
